### PR TITLE
Use fileutil.Cleanup to remove temporary directories in tests

### DIFF
--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"code-intelligence.com/cifuzz/util/fileutil"
 )
 
 func prepareTestDir(t *testing.T) (string, string) {
@@ -44,6 +46,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	executable, dir := prepareTestDir(t)
+	defer fileutil.Cleanup(dir)
 	fmt.Printf("executing cmake integration test in %s\n", dir)
 
 	//execute root command
@@ -75,6 +78,7 @@ func TestDirectoryFlagAndOutFlag(t *testing.T) {
 	}
 
 	executable, dir := prepareTestDir(t)
+	defer fileutil.Cleanup(dir)
 	fmt.Printf("executing cmake integration test in %s\n", dir)
 
 	//execute root command

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -10,6 +10,7 @@ import (
 
 	"code-intelligence.com/cifuzz/pkg/cmdutils"
 	"code-intelligence.com/cifuzz/pkg/storage"
+	"code-intelligence.com/cifuzz/util/fileutil"
 )
 
 func TestRootCmd(t *testing.T) {
@@ -26,7 +27,7 @@ func TestChangingToNonExistingDirectory(t *testing.T) {
 	require.NoError(t, err)
 	err = os.Chdir(testDir)
 	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	defer fileutil.Cleanup(testDir)
 
 	origWorkDir, err := os.Getwd()
 	require.NoError(t, err)
@@ -56,7 +57,7 @@ func TestChangingToExistingDirectory(t *testing.T) {
 	require.NoError(t, err)
 	err = os.Chdir(testDir)
 	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	defer fileutil.Cleanup(testDir)
 
 	origWorkDir, err := os.Getwd()
 	require.NoError(t, err)

--- a/tools/cmake/cmake_test.go
+++ b/tools/cmake/cmake_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"log"
 	"os"
@@ -14,6 +12,11 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"code-intelligence.com/cifuzz/util/fileutil"
 )
 
 var baseTempDir string
@@ -25,7 +28,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("Failed to create temp dir for tests: %+v", err)
 	}
-	defer os.RemoveAll(baseTempDir)
+	defer fileutil.Cleanup(baseTempDir)
 	m.Run()
 }
 

--- a/tools/replayer/replayer_test.go
+++ b/tools/replayer/replayer_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -15,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"code-intelligence.com/cifuzz/util/fileutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -206,7 +206,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("Failed to create temp dir for tests: %+v", err)
 	}
-	defer os.RemoveAll(baseTempDir)
+	defer fileutil.Cleanup(baseTempDir)
 	m.Run()
 }
 


### PR DESCRIPTION
This is based on #23 and should only be merged after #23 was merged.