### PR TITLE
Reintroduce IncorrectUsageError

### DIFF
--- a/pkg/cmdutils/errors.go
+++ b/pkg/cmdutils/errors.go
@@ -2,6 +2,7 @@ package cmdutils
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -10,5 +11,14 @@ var ErrSilent = errors.New("SilentError")
 // WrapSilentError wraps an existing error into ErrSilent
 // so we can silently fail if an expected error happens
 func WrapSilentError(err error) error {
+	return fmt.Errorf("%w:\n%+v", ErrSilent, err)
+}
+
+var ErrIncorrectUsage = errors.New("IncorrectUsageError")
+
+// WrapIncorrectUsageError wraps an existing error into
+// ErrIncorrectUsage so we can print a usage message when this error
+// is handled.
+func WrapIncorrectUsageError(err error) error {
 	return fmt.Errorf("%w:\n%+v", ErrSilent, err)
 }


### PR DESCRIPTION
We don't want to print the usage message on all unexpected errors, but
only for those errors which were caused by incorrect usage of the
command.