### PR TITLE
cmake: Set compiler and linker options

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -313,6 +313,8 @@ func commonBuildEnv() ([]string, error) {
 func setBuildFlagsEnvVars(env []string) ([]string, error) {
 	// Set CFLAGS and CXXFLAGS. Note that these flags must not contain
 	// spaces, because the environment variables are space separated.
+	//
+	// Note: Keep in sync with tools/cmake/CIFuzz/share/CIFuzz/CIFuzzFunctions.cmake
 	cflags := []string{
 		// ----- Common flags -----
 		// Keep debug symbols

--- a/tools/cmake/CIFuzz/share/CIFuzz/CIFuzzConfig.cmake
+++ b/tools/cmake/CIFuzz/share/CIFuzz/CIFuzzConfig.cmake
@@ -1,6 +1,7 @@
 include("${CMAKE_CURRENT_LIST_DIR}/CIFuzzTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/CIFuzzFunctions.cmake")
 
+set(CIFUZZ_TESTING false CACHE BOOL "Enable general compiler options for fuzzing and regression tests")
 set(CIFUZZ_ENGINE "replayer" CACHE STRING "The fuzzing engine used to run fuzz tests")
 set(CIFUZZ_SANITIZERS "" CACHE STRING "The sanitizers to instrument the code with")
 set(CIFUZZ_USE_DEPRECATED_MACROS OFF CACHE BOOL "Whether to use the deprecated FUZZ(_INIT) macros instead of FUZZ_TEST(_SETUP)")

--- a/tools/cmake/cmake_test.go
+++ b/tools/cmake/cmake_test.go
@@ -211,9 +211,11 @@ func runInDirWithExpectedStatus(t *testing.T, expectFailure bool, dir string, co
 	t.Logf("Working directory: %s", c.Dir)
 	t.Logf("Command: %s", c.String())
 	out, err := c.Output()
+	// Prints compiler command invocations to the test logs.
+	t.Log(string(out))
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		msg := fmt.Sprintf("%q exited with %d:\nstderr:\n%s\nstdout:\n%s", c.String(), exitErr.ExitCode(), string(exitErr.Stderr), string(out))
+		msg := fmt.Sprintf("%q exited with %d:\nstderr:\n%s", c.String(), exitErr.ExitCode(), string(exitErr.Stderr))
 		if !expectFailure {
 			require.NoError(t, exitErr, msg)
 		} else {
@@ -223,7 +225,7 @@ func runInDirWithExpectedStatus(t *testing.T, expectFailure bool, dir string, co
 		}
 		return nil
 	} else {
-		msg := fmt.Sprintf("%q failed to execute with error:%v\nstdout:\n%s", c.String(), err, string(out))
+		msg := fmt.Sprintf("%q failed to execute with error:%v\n", c.String(), err)
 		// Non-ExitErrors or context errors are never expected.
 		require.NoError(t, err, msg)
 		require.NoError(t, ctx.Err(), msg)

--- a/tools/cmake/testdata/CMakeLists.txt
+++ b/tools/cmake/testdata/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.19)
 
 project(CmakeTest)
 

--- a/tools/cmake/testdata/src/parser/parser.cpp
+++ b/tools/cmake/testdata/src/parser/parser.cpp
@@ -12,7 +12,7 @@ int parse(const std::string &input) {
   }
   const int bar = std::numeric_limits<int>::max() - 5;
   // Crashes with UndefinedBehaviorSanitizer.
-  if (bar + input[0] == 300) {
+  if (bar + input[0] == std::numeric_limits<int>::max()) {
     return -1;
   }
   if (input[0] == 'a' && input[1] == 'b' && input[2] == 'c') {


### PR DESCRIPTION
Add the same compiler and linker options as are set for make
invocations when using clang or gcc and adapt the set of flags for
MSVC-style compilers.