### PR TITLE
runner: Only set abort_on_error=0 when using libfuzzer

### DIFF
--- a/pkg/runner/libfuzzer/libfuzzer_runner.go
+++ b/pkg/runner/libfuzzer/libfuzzer_runner.go
@@ -321,6 +321,17 @@ func (r *Runner) FuzzerEnvironment() ([]string, error) {
 		return nil, err
 	}
 
+	overrideOptions := map[string]string{
+		// Per default this is set to false, except for darwin.
+		// To have consistent behaviour on all supported operating systems
+		// we are setting this explicitly to false
+		"abort_on_error": "0",
+	}
+	env, err = fuzzer_runner.SetASANOptions(env, nil, overrideOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return env, nil
 }
 

--- a/pkg/runner/runnerutils.go
+++ b/pkg/runner/runnerutils.go
@@ -122,10 +122,6 @@ func SetCommonASANOptions(env []string) ([]string, error) {
 		//   https://github.com/google/sanitizers/wiki/SanitizerCommonFlags
 		//
 		"exitcode": strconv.Itoa(SanitizerErrorExitCode),
-		// Per default this is set to false, except for darwin.
-		// To have consistent behaviour on all supported operating systems
-		// we are setting this explicitly to false
-		"abort_on_error": "0",
 	}
 	return SetASANOptions(env, defaultOptions, overrideOptions)
 }


### PR DESCRIPTION
AFL++ fails with

    Custom ASAN_OPTIONS set without abort_on_error=1 - please fix!

when abort_on_error=0 is set.