### PR TITLE
Use goimports-reviser for formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ endif
 binary_base_path = build/bin/cifuzz_
 test_fuzz_targets_path = testdata
 
+project := "code-intelligence.com/cifuzz"
+
 default:
 	@echo cifuzz
 
@@ -29,6 +31,7 @@ deps:
 .PHONY: deps/dev
 deps/dev: deps
 	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install github.com/incu6us/goimports-reviser/v2@latest
 
 .PHONY: build
 build: build/linux build/windows build/darwin ;
@@ -56,11 +59,15 @@ lint: deps/dev
 
 .PHONY: fmt
 fmt:
-	goimports -w -local code-intelligence.com .
+	find . -type f -name "*.go" -exec goimports-reviser -project-name $(project) -file-path {} \;
 
 .PHONY: fmt/check
 fmt/check:
-	if [ -n "$$(goimports -l -local code-intelligence.com .)" ]; then exit 1; fi;
+	@DIFF=$$(find . -type f -name "*.go" -exec goimports-reviser -project-name $(project) -list-diff -file-path {} \;); \
+	if [ -n "$$DIFF" ]; then \
+		echo >&2 "Unformatted files:\n$$DIFF"; \
+		exit 1; \
+	fi;
 
 .PHONY: tidy
 tidy:

--- a/pkg/minijail/minijail.go
+++ b/pkg/minijail/minijail.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"code-intelligence.com/cifuzz/pkg/log"
-
 	"code-intelligence.com/cifuzz/pkg/runfiles"
 	"code-intelligence.com/cifuzz/util/envutil"
 	"code-intelligence.com/cifuzz/util/fileutil"

--- a/pkg/runner/jazzer/jazzer_runner.go
+++ b/pkg/runner/jazzer/jazzer_runner.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"code-intelligence.com/cifuzz/pkg/minijail"
-
 	"code-intelligence.com/cifuzz/pkg/runfiles"
 	"code-intelligence.com/cifuzz/pkg/runner/libfuzzer"
 	"code-intelligence.com/cifuzz/util/envutil"

--- a/pkg/runner/runnerutils.go
+++ b/pkg/runner/runnerutils.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"golang.org/x/exp/maps"
 	"golang.org/x/term"
 


### PR DESCRIPTION
goimports doesn't group imports which are separated by an empty line,
which sometimes end up there when Intellij auto updates the imports.
    
goimports-reviser takes care of this.
