### PR TITLE
executil: Fix race when using CommandContext

### DIFF
--- a/pkg/runner/libfuzzer/libfuzzer_runner.go
+++ b/pkg/runner/libfuzzer/libfuzzer_runner.go
@@ -191,7 +191,6 @@ func (r *Runner) RunLibfuzzerAndReport(ctx context.Context, args []string, env [
 	}
 	defer cancelCmdCtx()
 	r.cmd = executil.CommandContext(cmdCtx, args[0], args[1:]...)
-	r.cmd.TerminateProcessGroupWhenContextDone = true
 	r.cmd.Env = env
 
 	var stderrPipe io.ReadCloser


### PR DESCRIPTION
By using exec.CommandContext, two go routines were started which waited
for the context to be done, one from the exec package which immediately
sends a SIGKILL to the started process and one from the executil package
which first sends a SIGTERM to the process group and after a grace
period a SIGKILL.

As a result, the started process itself usually didn't have time to shut
down gracefully, because it received a SIGKILL at about the same time as
the SIGTERM.

To fix this, executil.CommandContext now doesn't use exec.CommandContext
anymore but exec.Command, so the exec package doesn't handle killing the
process anymore. Because callers expect that using
executil.CommandContext will terminate the process when the context is
done, the process group is now always terminated when the context is
done and therefore the Cmd.TerminateProcessGroupWhenContextDone field
was removed.