### PR TITLE
runner: Print startup stderr in case of an unexpected exit error

### DIFF
--- a/pkg/runner/libfuzzer/libfuzzer_runner.go
+++ b/pkg/runner/libfuzzer/libfuzzer_runner.go
@@ -265,6 +265,12 @@ func (r *Runner) RunLibfuzzerAndReport(ctx context.Context, args []string, env [
 			}
 
 			if !IsExpectedExitError(err) {
+				// Print the stderr output of the fuzzer up to the point where
+				// it has been successfully initialized to provide users with
+				// the context of this abnormal exit even without verbose mode.
+				if !r.Verbose {
+					_, _ = log.NewPTermWriter().Write(reporter.StartupOutput())
+				}
 				return errors.WithMessagef(err, "Unexpected exit code %d", exitErr.ExitCode())
 			}
 

--- a/pkg/runner/libfuzzer/libfuzzer_runner.go
+++ b/pkg/runner/libfuzzer/libfuzzer_runner.go
@@ -269,7 +269,7 @@ func (r *Runner) RunLibfuzzerAndReport(ctx context.Context, args []string, env [
 				// it has been successfully initialized to provide users with
 				// the context of this abnormal exit even without verbose mode.
 				if !r.Verbose {
-					_, _ = log.NewPTermWriter().Write(reporter.StartupOutput())
+					log.Print(reporter.StartupOutput())
 				}
 				return errors.WithMessagef(err, "Unexpected exit code %d", exitErr.ExitCode())
 			}


### PR DESCRIPTION
Without the stderr of the fuzzer printed during startup, it isn't
possible for users to understand why it exits abnormally, e.g. due to a
missing shared library dependency.

With this commit, the parsed output up to the point where the fuzzer has
been initialized is stored and made available to the runner to print in
case of an error.