### PR TITLE
integration-tests: Use deterministic random seed

### DIFF
--- a/integration-tests/cmake/cmake_test.go
+++ b/integration-tests/cmake/cmake_test.go
@@ -116,7 +116,7 @@ func runFuzzer(t *testing.T, cifuzz string, dir string, expectedOutput *regexp.R
 	const timeout = 2 * time.Minute
 	runCtx, closeRunCtx := context.WithTimeout(context.Background(), timeout)
 	defer closeRunCtx()
-	cmd := executil.CommandContext(runCtx, cifuzz, "run", "parser_fuzz_test")
+	cmd := executil.CommandContext(runCtx, cifuzz, "run", "parser_fuzz_test", "--engine-arg=-seed=1")
 	cmd.Dir = dir
 	stdoutPipe, err := cmd.StdoutTeePipe(os.Stdout)
 	require.NoError(t, err)


### PR DESCRIPTION
... to reduce flakiness.