### PR TITLE
envutil: Use os.PathListSeparator

### DIFF
--- a/pkg/runner/runnerutils.go
+++ b/pkg/runner/runnerutils.go
@@ -189,7 +189,7 @@ func FuzzerEnvironment() ([]string, error) {
 func SetLDLibraryPath(env []string, libraryDirs []string) ([]string, error) {
 	// Add directories from the library dir flags to LD_LIBRARY_PATH
 	var libDirsList string
-	libDirsList = envutil.AddToColonSeparatedList(libDirsList, libraryDirs...)
+	libDirsList = envutil.AppendToPathList(libDirsList, libraryDirs...)
 	return envutil.Setenv(env, "LD_LIBRARY_PATH", libDirsList)
 }
 

--- a/util/envutil/envutil.go
+++ b/util/envutil/envutil.go
@@ -1,6 +1,7 @@
 package envutil
 
 import (
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -9,16 +10,18 @@ import (
 	"code-intelligence.com/cifuzz/util/stringutil"
 )
 
-// AddToColonSeparatedList appends a string to another string containing
-// a list of colon-separated strings (like the PATH and LD_LIBRARY_PATH
-// environment variables do). It doesn't add duplicates and removes any
-// empty strings from the list.
-func AddToColonSeparatedList(list string, value ...string) string {
+const sep = string(os.PathListSeparator)
+
+// AppendToPathList appends a string to another string containing a list
+// of paths, separated by os.PathListSeparator (like the PATH and
+// LD_LIBRARY_PATH environment variables). It doesn't add duplicates and
+// removes any empty strings from the list.
+func AppendToPathList(list string, value ...string) string {
 	if len(value) == 0 {
 		return list
 	}
 
-	values := strings.Split(list, ":")
+	values := strings.Split(list, sep)
 
 	for _, newVal := range value {
 		if !sliceutil.Contains(values, newVal) {
@@ -26,7 +29,7 @@ func AddToColonSeparatedList(list string, value ...string) string {
 		}
 	}
 
-	return stringutil.JoinNonEmpty(values, ":")
+	return stringutil.JoinNonEmpty(values, sep)
 }
 
 // Like os.LookupEnv but uses the specified environment instead of the

--- a/util/envutil/envutil_test.go
+++ b/util/envutil/envutil_test.go
@@ -6,22 +6,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddToColonSeparatedList(t *testing.T) {
+func TestAppendToPathList(t *testing.T) {
 	// Check values successfully added
-	require.Equal(t, "foo", AddToColonSeparatedList("", "foo"))
-	require.Equal(t, "foo:bar", AddToColonSeparatedList("foo", "bar"))
-	require.Equal(t, "foo:bar:baz", AddToColonSeparatedList("foo:bar", "baz"))
+	require.Equal(t, "foo", AppendToPathList("", "foo"))
+	require.Equal(t, "foo"+sep+"bar", AppendToPathList("foo", "bar"))
+	require.Equal(t, "foo"+sep+"bar"+sep+"baz", AppendToPathList("foo"+sep+"bar", "baz"))
 	// Check no duplicates added
-	require.Equal(t, "foo", AddToColonSeparatedList("foo", "foo"))
-	require.Equal(t, "foo:bar", AddToColonSeparatedList("foo:bar", "foo"))
-	require.Equal(t, "foo:bar", AddToColonSeparatedList("foo:bar", "bar"))
+	require.Equal(t, "foo", AppendToPathList("foo", "foo"))
+	require.Equal(t, "foo"+sep+"bar", AppendToPathList("foo"+sep+"bar", "foo"))
+	require.Equal(t, "foo"+sep+"bar", AppendToPathList("foo"+sep+"bar", "bar"))
 	// Check no empty values added
-	require.Equal(t, "foo", AddToColonSeparatedList("foo"))
-	require.Equal(t, "foo", AddToColonSeparatedList("foo", ""))
-	require.Equal(t, "foo:bar", AddToColonSeparatedList("foo:bar", ""))
+	require.Equal(t, "foo", AppendToPathList("foo"))
+	require.Equal(t, "foo", AppendToPathList("foo", ""))
+	require.Equal(t, "foo"+sep+"bar", AppendToPathList("foo"+sep+"bar", ""))
 	// Check multiple values added
-	require.Equal(t, "foo:bar", AddToColonSeparatedList("", "foo", "bar"))
-	require.Equal(t, "foo:bar:baz", AddToColonSeparatedList("foo", "bar", "baz"))
+	require.Equal(t, "foo"+sep+"bar", AppendToPathList("", "foo", "bar"))
+	require.Equal(t, "foo"+sep+"bar"+sep+"baz", AppendToPathList("foo", "bar", "baz"))
 }
 
 func TestSetenv(t *testing.T) {


### PR DESCRIPTION
The purpose of the AddToColonSeparatedList function is to add paths to
the PATH or LD_LIBRARY_PATH environment variables, which are not
colon-separated on Windows, so we now use os.PathListSeparator instead.