### PR TITLE
runner: Fix startup output printed as bytes

### DIFF
--- a/pkg/parser/libfuzzer/libfuzzer_parser.go
+++ b/pkg/parser/libfuzzer/libfuzzer_parser.go
@@ -119,8 +119,8 @@ func (p *parser) Parse(ctx context.Context, input io.Reader, reportsCh chan *rep
 	return nil
 }
 
-func (p *parser) StartupOutput() []byte {
-	return p.startupOutput.Bytes()
+func (p *parser) StartupOutput() string {
+	return p.startupOutput.String()
 }
 
 func (p *parser) sendReport(ctx context.Context, report *report.Report) error {


### PR DESCRIPTION
The startup output was printed as an array of bytes, see for example https://github.com/CodeIntelligenceTesting/cifuzz/runs/7211896842?check_suite_focus=true#step:9:71