### PR TITLE
Call fsync after copying

### DIFF
--- a/pkg/runner/libfuzzer/integration-tests/crashing_corpus_entry_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/crashing_corpus_entry_test.go
@@ -6,11 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/otiai10/copy"
 	"github.com/stretchr/testify/require"
 
 	"code-intelligence.com/cifuzz/pkg/report"
 	"code-intelligence.com/cifuzz/pkg/runner/libfuzzer/integration-tests/testutils"
-	"code-intelligence.com/cifuzz/util/fileutil"
 )
 
 func TestIntegration_CrashingCorpusEntry(t *testing.T) {
@@ -44,7 +44,7 @@ func makeTemporarySeedCorpusDir(t *testing.T) string {
 	require.NoError(t, err)
 
 	require.NoError(t, err)
-	err = fileutil.CopyFile(crashingInput, filepath.Join(tmpCorpusDir, "crashing_input"), 0644)
+	err = copy.Copy(crashingInput, filepath.Join(tmpCorpusDir, "crashing_input"), copy.Options{Sync: true})
 	require.NoError(t, err)
 
 	entries, err := os.ReadDir(tmpCorpusDir)

--- a/tools/install/installer.go
+++ b/tools/install/installer.go
@@ -160,15 +160,15 @@ func (i *installer) InstallMinijail() error {
 	// Install minijail binaries
 	src := filepath.Join(i.projectDir, "third-party/minijail/minijail0")
 	dest := filepath.Join(i.binDir(), "minijail0")
-	err = fileutil.CopyFile(src, dest, 0700)
+	err = copy.Copy(src, dest, copy.Options{Sync: true})
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	src = filepath.Join(i.projectDir, "third-party/minijail/libminijailpreload.so")
 	dest = filepath.Join(i.libDir(), "libminijailpreload.so")
-	err = fileutil.CopyFile(src, dest, 0600)
+	err = copy.Copy(src, dest, copy.Options{Sync: true})
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	return nil

--- a/util/fileutil/fileutil.go
+++ b/util/fileutil/fileutil.go
@@ -1,8 +1,6 @@
 package fileutil
 
 import (
-	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,20 +61,6 @@ func Cleanup(path string) {
 	if err != nil {
 		log.Warnf("%+v", errors.WithStack(err))
 	}
-}
-
-// CopyFile creates a copy of src at dest in a simple and not very
-// efficient way.
-func CopyFile(src, dest string, perm fs.FileMode) error {
-	bytes, err := ioutil.ReadFile(src)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	err = ioutil.WriteFile(dest, bytes, perm)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
 }
 
 // PrettifyPath prints a possibly shortened path for display purposes.


### PR DESCRIPTION
We've seen some errors in CI pipelines indicating that the files copied
by the installer are being used before they were synced to disk, so we
now sync after copying.

The Copy function from github.com/otiai10/copy already supports syncing
after copying, so we're using that now instead of fileutil.CopyFile.

Note that this might not fix all synchronization issues, quoting the
fsync(2) manual:

    Calling fsync() does not necessarily ensure that the entry in the directory
    containing the file has also reached disk.  For that an explicit fsync() on
    a file descriptor for the directory is also needed.

So in case we still see synchronization issues, we should also call fsync
on the directory of the file we copied.