### PR TITLE
installer: Call fsync on the directory after copying

### DIFF
--- a/tools/install/installer.go
+++ b/tools/install/installer.go
@@ -164,11 +164,24 @@ func (i *installer) InstallMinijail() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	// fsync the directory to ensure that the directory entry has
+	// reached disk
+	err = fileutil.Sync(i.binDir())
+	if err != nil {
+		return err
+	}
+
 	src = filepath.Join(i.projectDir, "third-party/minijail/libminijailpreload.so")
 	dest = filepath.Join(i.libDir(), "libminijailpreload.so")
 	err = copy.Copy(src, dest, copy.Options{Sync: true})
 	if err != nil {
 		return errors.WithStack(err)
+	}
+	// fsync the directory to ensure that the directory entry has
+	// reached disk
+	err = fileutil.Sync(i.libDir())
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/util/fileutil/fileutil.go
+++ b/util/fileutil/fileutil.go
@@ -63,6 +63,22 @@ func Cleanup(path string) {
 	}
 }
 
+func Sync(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if syncErr != nil {
+		return errors.WithStack(syncErr)
+	}
+	if closeErr != nil {
+		return errors.WithStack(closeErr)
+	}
+	return nil
+}
+
 // PrettifyPath prints a possibly shortened path for display purposes.
 // If path is located under the current working directory, the relative path to
 // it is returned, otherwise or in case of an error the path is returned


### PR DESCRIPTION
We still saw synchronization issues since we implemented calling fsync on the file in 65b1930006a819dd56b0243e995fb1244cdd9833.
