### PR TITLE
runner tests: Log to buffer instead modifying os.Stderr

### DIFF
--- a/internal/cmd/run/report_handler/report_handler.go
+++ b/internal/cmd/run/report_handler/report_handler.go
@@ -195,7 +195,7 @@ func (h *ReportHandler) PrintFinalMetrics(numSeeds uint) error {
 			metrics.DescString(" (total: %s)", metrics.NumberString("%d", totalSeeds)),
 	}
 
-	w := tabwriter.NewWriter(log.NewPTermWriter(), 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(log.NewPTermWriter(os.Stderr), 0, 0, 1, ' ', 0)
 	for _, line := range lines {
 		_, err := fmt.Fprintln(w, line)
 		if err != nil {

--- a/pkg/log/ptermwriter.go
+++ b/pkg/log/ptermwriter.go
@@ -2,7 +2,7 @@ package log
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -18,12 +18,13 @@ var writeLock sync.Mutex
 
 type ptermWriter struct {
 	buf []byte
+	out io.Writer
 }
 
 // NewPTermWriter returns a writer which ensures that the output written
 // by it doesn't mess with the output of an active pterm.SpinnerPrinter.
-func NewPTermWriter() *ptermWriter {
-	return &ptermWriter{}
+func NewPTermWriter(out io.Writer) *ptermWriter {
+	return &ptermWriter{out: out}
 }
 
 func (w *ptermWriter) Write(p []byte) (n int, err error) {
@@ -50,8 +51,8 @@ func (w *ptermWriter) Write(p []byte) (n int, err error) {
 		ActiveUpdatingPrinter.Clear()
 	}
 
-	// Write the buffer to stderr
-	n, err = fmt.Fprint(os.Stderr, string(w.buf))
+	// Write the buffer
+	n, err = fmt.Fprint(w.out, string(w.buf))
 
 	// Clear the buffer now that it was written
 	w.buf = []byte{}

--- a/pkg/runner/libfuzzer/integration-tests/asan_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/asan_test.go
@@ -17,7 +17,7 @@ func TestIntegration_ASAN(t *testing.T) {
 	testutils.TestWithAndWithoutMinijail(t, func(t *testing.T, disableMinijail bool) {
 		test := testutils.NewLibfuzzerTest(t, "trigger_asan", disableMinijail)
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		testutils.CheckReports(t, reports, &testutils.CheckReportOptions{
 			ErrorType:   report.ErrorType_CRASH,

--- a/pkg/runner/libfuzzer/integration-tests/crashing_corpus_entry_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/crashing_corpus_entry_test.go
@@ -25,7 +25,7 @@ func TestIntegration_CrashingCorpusEntry(t *testing.T) {
 		test.RunsLimit = 0
 		test.SeedCorpusDir = makeTemporarySeedCorpusDir(t)
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		testutils.CheckReports(t, reports, &testutils.CheckReportOptions{
 			ErrorType:   report.ErrorType_CRASH,

--- a/pkg/runner/libfuzzer/integration-tests/empty_input_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/empty_input_test.go
@@ -20,7 +20,7 @@ func TestIntegration_CrashOnEmptyInput(t *testing.T) {
 	testutils.TestWithAndWithoutMinijail(t, func(t *testing.T, disableMinijail bool) {
 		test := testutils.NewLibfuzzerTest(t, "trigger_asan_on_empty_input", disableMinijail)
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		errMsg := "SEGV on unknown address"
 		if runtime.GOOS == "windows" {

--- a/pkg/runner/libfuzzer/integration-tests/input_timeout_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/input_timeout_test.go
@@ -21,7 +21,7 @@ func TestIntegration_InputTimeout(t *testing.T) {
 		test.RunsLimit = 1
 		test.EngineArgs = append(test.EngineArgs, "-timeout=1")
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		options := &testutils.CheckReportOptions{
 			ErrorType:   report.ErrorType_CRASH,

--- a/pkg/runner/libfuzzer/integration-tests/oom_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/oom_test.go
@@ -18,7 +18,7 @@ func TestIntegration_OOM(t *testing.T) {
 		test := testutils.NewLibfuzzerTest(t, "trigger_oom", disableMinijail)
 		test.EngineArgs = append(test.EngineArgs, "-malloc_limit_mb=1")
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		testutils.CheckReports(t, reports, &testutils.CheckReportOptions{
 			ErrorType:   report.ErrorType_CRASH,

--- a/pkg/runner/libfuzzer/integration-tests/slow_input_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/slow_input_test.go
@@ -20,7 +20,7 @@ func TestIntegration_SlowInput(t *testing.T) {
 		test.RunsLimit = 1
 		test.EngineArgs = append(test.EngineArgs, "-report_slow_units=1")
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		testutils.CheckReports(t, reports, &testutils.CheckReportOptions{
 			ErrorType:   report.ErrorType_WARNING,

--- a/pkg/runner/libfuzzer/integration-tests/test_cases_written_to_corpus_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/test_cases_written_to_corpus_test.go
@@ -16,7 +16,7 @@ func TestIntegration_CasesWrittenToCorpus(t *testing.T) {
 	testutils.TestWithAndWithoutMinijail(t, func(t *testing.T, disableMinijail bool) {
 		test := testutils.NewLibfuzzerTest(t, "new_paths_fuzzer", disableMinijail)
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		testutils.CheckReports(t, reports, &testutils.CheckReportOptions{
 			NumFindings: 0,

--- a/pkg/runner/libfuzzer/integration-tests/timeout_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/timeout_test.go
@@ -24,7 +24,7 @@ func TestIntegration_Timeout(t *testing.T) {
 		// reached.
 		test.RunsLimit = -1
 
-		_, stderr, _ := test.Run(t)
-		require.Contains(t, stderr, "DONE")
+		output, _ := test.Run(t)
+		require.Contains(t, output, "DONE")
 	})
 }

--- a/pkg/runner/libfuzzer/integration-tests/ubsan_non_recoverable_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/ubsan_non_recoverable_test.go
@@ -19,7 +19,7 @@ func TestIntegration_UBSANNonRecoverable(t *testing.T) {
 	testutils.TestWithAndWithoutMinijail(t, func(t *testing.T, disableMinijail bool) {
 		test := testutils.NewLibfuzzerTest(t, "trigger_ubsan_non_recoverable", disableMinijail)
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		testutils.CheckReports(t, reports, &testutils.CheckReportOptions{
 			ErrorType:   report.ErrorType_RUNTIME_ERROR,

--- a/pkg/runner/libfuzzer/integration-tests/ubsan_recoverable_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/ubsan_recoverable_test.go
@@ -19,7 +19,7 @@ func TestIntegration_UBSANRecoverable(t *testing.T) {
 	testutils.TestWithAndWithoutMinijail(t, func(t *testing.T, disableMinijail bool) {
 		test := testutils.NewLibfuzzerTest(t, "trigger_ubsan", disableMinijail)
 
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		testutils.CheckReports(t, reports, &testutils.CheckReportOptions{
 			ErrorType:           report.ErrorType_RUNTIME_ERROR,

--- a/pkg/runner/libfuzzer/integration-tests/with_env_vars_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/with_env_vars_test.go
@@ -22,8 +22,8 @@ func TestIntegration_WithEnvs_NoStatsPrinted(t *testing.T) {
 		test.FuzzerEnv = []string{"ASAN_OPTIONS=print_stats=0"}
 		test.Timeout = time.Second
 
-		_, stderr, _ := test.Run(t)
-		require.NotContains(t, stderr, "Stats:")
+		output, _ := test.Run(t)
+		require.NotContains(t, output, "Stats:")
 	})
 }
 
@@ -37,8 +37,8 @@ func TestIntegration_WithEnvs_StatsPrinted(t *testing.T) {
 		test.FuzzerEnv = []string{"ASAN_OPTIONS=print_stats=1:atexit=1"}
 		test.Timeout = time.Second
 
-		_, stderr, _ := test.Run(t)
-		require.Contains(t, stderr, "Stats:")
+		output, _ := test.Run(t)
+		require.Contains(t, output, "Stats:")
 	})
 }
 

--- a/pkg/runner/libfuzzer/integration-tests/with_file_accesses_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/with_file_accesses_test.go
@@ -20,7 +20,7 @@ func TestIntegration_WithFileAccesses(t *testing.T) {
 		// change to the build directory of the fuzz targets to make sure
 		// that the needed example.conf is found
 		test.ExecutionDir = testutils.GetFuzzTargetBuildDir(t)
-		_, _, reports := test.Run(t)
+		_, reports := test.Run(t)
 
 		testutils.CheckReports(t, reports, &testutils.CheckReportOptions{
 			ErrorType:   report.ErrorType_CRASH,

--- a/pkg/runner/libfuzzer/libfuzzer_runner.go
+++ b/pkg/runner/libfuzzer/libfuzzer_runner.go
@@ -49,6 +49,7 @@ type RunnerOptions struct {
 	UseMinijail         bool
 	Verbose             bool
 	KeepColor           bool
+	LogOutput           io.Writer
 }
 
 func (options *RunnerOptions) ValidateOptions() error {
@@ -68,6 +69,10 @@ func (options *RunnerOptions) ValidateOptions() error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+	}
+
+	if options.LogOutput == nil {
+		options.LogOutput = os.Stderr
 	}
 
 	return nil
@@ -201,7 +206,7 @@ func (r *Runner) RunLibfuzzerAndReport(ctx context.Context, args []string, env [
 		// Note that this causes the command's stdout to be printed to
 		// stderr, which is what we want, because we only want reports
 		// printed to stdout.
-		ptermWriter := log.NewPTermWriter()
+		ptermWriter := log.NewPTermWriter(r.LogOutput)
 		r.cmd.Stdout = ptermWriter
 
 		// Write the command's stderr to both a pipe and the pterm


### PR DESCRIPTION
Modifying the global variable os.Stderr caused "broken pipe" errors when
running the tests in parallel.