### PR TITLE
Revert ineffective integration test fixes

### DIFF
--- a/integration-tests/cmake/cmake_test.go
+++ b/integration-tests/cmake/cmake_test.go
@@ -322,8 +322,6 @@ func modifyFuzzTestToCallFunction(t *testing.T, fuzzTestPath string) {
 	require.NoError(t, err)
 	_, err = f.WriteString(strings.Join(lines, "\n"))
 	require.NoError(t, err)
-	err = f.Close()
-	require.NoError(t, err)
 
 	// Add dependency on parser lib to CMakeLists.txt
 	cmakeLists := filepath.Join(filepath.Dir(fuzzTestPath), "CMakeLists.txt")
@@ -331,7 +329,5 @@ func modifyFuzzTestToCallFunction(t *testing.T, fuzzTestPath string) {
 	require.NoError(t, err)
 	defer f.Close()
 	_, err = f.WriteString("target_link_libraries(parser_fuzz_test PRIVATE parser)\n")
-	require.NoError(t, err)
-	err = f.Close()
 	require.NoError(t, err)
 }

--- a/tools/install/installer.go
+++ b/tools/install/installer.go
@@ -114,19 +114,6 @@ func (i *installer) Cleanup() {
 	fileutil.Cleanup(i.InstallDir)
 }
 
-// Sync executes sync(1) to flush the disk cache
-func (i *installer) Sync() error {
-	// Windows doesn't come with a command like sync(1)
-	if runtime.GOOS == "windows" {
-		return nil
-	}
-	cmd := exec.Command("sync")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	return errors.WithStack(err)
-}
-
 func (i *installer) InstallCIFuzzAndDeps() error {
 	var err error
 	if runtime.GOOS == "linux" {
@@ -174,12 +161,6 @@ func (i *installer) InstallMinijail() error {
 		return errors.WithStack(err)
 	}
 
-	// Flush disk cache before copying the created files
-	err = i.Sync()
-	if err != nil {
-		return err
-	}
-
 	// Install minijail binaries
 	src := filepath.Join(i.projectDir, "third-party", "minijail", "minijail0")
 	dest := filepath.Join(i.binDir(), "minijail0")
@@ -194,7 +175,7 @@ func (i *installer) InstallMinijail() error {
 		return errors.WithStack(err)
 	}
 
-	return i.Sync()
+	return nil
 }
 
 func (i *installer) InstallProcessWrapper() error {
@@ -212,8 +193,7 @@ func (i *installer) InstallProcessWrapper() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	return i.Sync()
+	return nil
 }
 
 func (i *installer) InstallCIFuzz() error {
@@ -227,8 +207,7 @@ func (i *installer) InstallCIFuzz() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	return i.Sync()
+	return nil
 }
 
 func (i *installer) InstallCMakeIntegration() error {
@@ -249,13 +228,7 @@ func (i *installer) InstallCMakeIntegration() error {
 	if err != nil {
 		return err
 	}
-
-	err = registerCMakePackage(dirForRegistry)
-	if err != nil {
-		return err
-	}
-
-	return i.Sync()
+	return registerCMakePackage(dirForRegistry)
 }
 
 func (i *installer) PrintPathInstructions() {


### PR DESCRIPTION
This reverts the following commits as the root cause of the integration
test failures turned out to be something else:
* 373f2de1d840916ed7f1c3fc11d29e07b0dbe1e9
* dcc5fd2ab62b3476f9505f94e21cac619978ba9e