### PR TITLE
Revert "TMP: integration-tests: Close files eagerly"

### DIFF
--- a/integration-tests/cmake/cmake_test.go
+++ b/integration-tests/cmake/cmake_test.go
@@ -322,8 +322,6 @@ func modifyFuzzTestToCallFunction(t *testing.T, fuzzTestPath string) {
 	require.NoError(t, err)
 	_, err = f.WriteString(strings.Join(lines, "\n"))
 	require.NoError(t, err)
-	err = f.Close()
-	require.NoError(t, err)
 
 	// Add dependency on parser lib to CMakeLists.txt
 	cmakeLists := filepath.Join(filepath.Dir(fuzzTestPath), "CMakeLists.txt")
@@ -331,7 +329,5 @@ func modifyFuzzTestToCallFunction(t *testing.T, fuzzTestPath string) {
 	require.NoError(t, err)
 	defer f.Close()
 	_, err = f.WriteString("target_link_libraries(parser_fuzz_test PRIVATE parser)\n")
-	require.NoError(t, err)
-	err = f.Close()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This reverts commit dcc5fd2ab62b3476f9505f94e21cac619978ba9e.

This did not address the root cause of the integration test issue.