### PR TITLE
Revert commits which call sync or fsync

### DIFF
--- a/pkg/runner/libfuzzer/integration-tests/crashing_corpus_entry_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/crashing_corpus_entry_test.go
@@ -43,7 +43,7 @@ func makeTemporarySeedCorpusDir(t *testing.T) string {
 	require.NoError(t, err)
 
 	require.NoError(t, err)
-	err = copy.Copy(crashingInput, filepath.Join(tmpCorpusDir, "crashing_input"), copy.Options{Sync: true})
+	err = copy.Copy(crashingInput, filepath.Join(tmpCorpusDir, "crashing_input"))
 	require.NoError(t, err)
 
 	entries, err := os.ReadDir(tmpCorpusDir)


### PR DESCRIPTION
... because they don't fix the synchronization issues we were trying
to fix.

This reverts commits 373f2de1d840916ed7f1c3fc11d29e07b0dbe1e9 and
65b1930006a819dd56b0243e995fb1244cdd9833.