### PR TITLE
run: Always use directory below .cifuzz-corpus as generated corpus dir

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -411,8 +411,8 @@ func setBuildFlagsEnvVars(env []string) ([]string, error) {
 	return env, nil
 }
 
-func countSeeds(seedDirs []string) (numSeeds uint, err error) {
-	for _, dir := range seedDirs {
+func countSeeds(seedCorpusDirs []string) (numSeeds uint, err error) {
+	for _, dir := range seedCorpusDirs {
 		var seedsInDir uint
 		err = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {

--- a/pkg/runner/jazzer/jazzer_runner.go
+++ b/pkg/runner/jazzer/jazzer_runner.go
@@ -108,10 +108,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	// Tell libfuzzer which corpus directory it should use
-	args = append(args, r.SeedsDir)
+	args = append(args, r.GeneratedCorpusDir)
 
 	// Add any additional corpus directories as further positional arguments
-	args = append(args, r.AdditionalSeedsDirs...)
+	args = append(args, r.SeedCorpusDirs...)
 
 	// -----------------------------
 	// --- fuzz target arguments ---
@@ -141,10 +141,10 @@ func (r *Runner) Run(ctx context.Context) error {
 			{Source: agentPath},
 			// The first corpus directory must be writable, because
 			// libfuzzer writes new test inputs to it
-			{Source: r.SeedsDir, Writable: minijail.ReadWrite},
+			{Source: r.GeneratedCorpusDir, Writable: minijail.ReadWrite},
 		}
 
-		for _, dir := range r.AdditionalSeedsDirs {
+		for _, dir := range r.SeedCorpusDirs {
 			bindings = append(bindings, &minijail.Binding{Source: dir})
 		}
 

--- a/pkg/runner/libfuzzer/integration-tests/crashing_corpus_entry_test.go
+++ b/pkg/runner/libfuzzer/integration-tests/crashing_corpus_entry_test.go
@@ -22,7 +22,7 @@ func TestIntegration_CrashingCorpusEntry(t *testing.T) {
 	TestWithAndWithoutMinijail(t, func(t *testing.T, disableMinijail bool) {
 		test := NewLibfuzzerTest(t, buildDir, "trigger_asan", disableMinijail)
 		test.RunsLimit = 0
-		test.SeedCorpusDir = makeTemporarySeedCorpusDir(t)
+		test.GeneratedCorpusDir = makeTemporarySeedCorpusDir(t)
 
 		_, reports := test.Run(t)
 

--- a/pkg/runner/libfuzzer/integration-tests/runner_testutils.go
+++ b/pkg/runner/libfuzzer/integration-tests/runner_testutils.go
@@ -38,16 +38,16 @@ func (cp *ChannelPassthrough) Handle(report *report.Report) error {
 
 // RunnerTest helps to execute tests for the runner package
 type RunnerTest struct {
-	FuzzTarget      string
-	Engine          config.Engine
-	SeedCorpusDir   string
-	Timeout         time.Duration
-	EngineArgs      []string
-	FuzzTargetArgs  []string
-	FuzzerEnv       []string
-	DisableMinijail bool
-	RunsLimit       int
-	LogOutput       *bytes.Buffer
+	FuzzTarget         string
+	Engine             config.Engine
+	GeneratedCorpusDir string
+	Timeout            time.Duration
+	EngineArgs         []string
+	FuzzTargetArgs     []string
+	FuzzerEnv          []string
+	DisableMinijail    bool
+	RunsLimit          int
+	LogOutput          *bytes.Buffer
 }
 
 func NewLibfuzzerTest(t *testing.T, buildDir, fuzzTarget string, disableMinijail bool) *RunnerTest {
@@ -70,12 +70,12 @@ func NewLibfuzzerTest(t *testing.T, buildDir, fuzzTarget string, disableMinijail
 func (test *RunnerTest) Start(t *testing.T, reportCh chan *report.Report) error {
 	var err error
 
-	if test.SeedCorpusDir == "" {
-		test.SeedCorpusDir, err = os.MkdirTemp("", "seeds")
+	if test.GeneratedCorpusDir == "" {
+		test.GeneratedCorpusDir, err = os.MkdirTemp("", "corpus")
 		require.NoError(t, err)
 	}
 
-	additionalSeedDir, err := os.MkdirTemp("", "additional_seeds")
+	seedCorpusDir, err := os.MkdirTemp("", "seeds")
 	require.NoError(t, err)
 
 	if test.RunsLimit != -1 {
@@ -85,8 +85,8 @@ func (test *RunnerTest) Start(t *testing.T, reportCh chan *report.Report) error 
 
 	libfuzzerOptions := &libfuzzer.RunnerOptions{
 		FuzzTarget:         test.FuzzTarget,
-		GeneratedCorpusDir: test.SeedCorpusDir,
-		SeedCorpusDirs:     []string{additionalSeedDir},
+		GeneratedCorpusDir: test.GeneratedCorpusDir,
+		SeedCorpusDirs:     []string{seedCorpusDir},
 		Timeout:            test.Timeout,
 		EngineArgs:         test.EngineArgs,
 		FuzzTargetArgs:     test.FuzzTargetArgs,
@@ -126,7 +126,7 @@ func (test *RunnerTest) Run(t *testing.T) (string, []*report.Report) {
 }
 
 func (test *RunnerTest) RequireSeedCorpusNotEmpty(t *testing.T) {
-	seeds, err := os.ReadDir(test.SeedCorpusDir)
+	seeds, err := os.ReadDir(test.GeneratedCorpusDir)
 	require.NoError(t, err)
-	require.NotEmpty(t, seeds, "corpus directory is empty: %s", test.SeedCorpusDir)
+	require.NotEmpty(t, seeds, "corpus directory is empty: %s", test.GeneratedCorpusDir)
 }

--- a/pkg/runner/libfuzzer/integration-tests/runner_testutils.go
+++ b/pkg/runner/libfuzzer/integration-tests/runner_testutils.go
@@ -84,15 +84,15 @@ func (test *RunnerTest) Start(t *testing.T, reportCh chan *report.Report) error 
 	}
 
 	libfuzzerOptions := &libfuzzer.RunnerOptions{
-		FuzzTarget:          test.FuzzTarget,
-		SeedsDir:            test.SeedCorpusDir,
-		AdditionalSeedsDirs: []string{additionalSeedDir},
-		Timeout:             test.Timeout,
-		EngineArgs:          test.EngineArgs,
-		FuzzTargetArgs:      test.FuzzTargetArgs,
-		EnvVars:             test.FuzzerEnv,
-		UseMinijail:         !test.DisableMinijail,
-		ReportHandler:       &ChannelPassthrough{ch: reportCh},
+		FuzzTarget:         test.FuzzTarget,
+		GeneratedCorpusDir: test.SeedCorpusDir,
+		SeedCorpusDirs:     []string{additionalSeedDir},
+		Timeout:            test.Timeout,
+		EngineArgs:         test.EngineArgs,
+		FuzzTargetArgs:     test.FuzzTargetArgs,
+		EnvVars:            test.FuzzerEnv,
+		UseMinijail:        !test.DisableMinijail,
+		ReportHandler:      &ChannelPassthrough{ch: reportCh},
 		// To ease debugging, we write the output to stderr in addition
 		// to the test.LogOutput buffer
 		LogOutput: io.MultiWriter(test.LogOutput, os.Stderr),

--- a/pkg/runner/libfuzzer/libfuzzer_runner.go
+++ b/pkg/runner/libfuzzer/libfuzzer_runner.go
@@ -36,20 +36,20 @@ const (
 )
 
 type RunnerOptions struct {
-	FuzzTarget          string
-	SeedsDir            string
-	AdditionalSeedsDirs []string
-	Dictionary          string
-	LibraryDirs         []string
-	EnvVars             []string
-	EngineArgs          []string
-	FuzzTargetArgs      []string
-	ReportHandler       report.Handler
-	Timeout             time.Duration
-	UseMinijail         bool
-	Verbose             bool
-	KeepColor           bool
-	LogOutput           io.Writer
+	FuzzTarget         string
+	GeneratedCorpusDir string
+	SeedCorpusDirs     []string
+	Dictionary         string
+	LibraryDirs        []string
+	EnvVars            []string
+	EngineArgs         []string
+	FuzzTargetArgs     []string
+	ReportHandler      report.Handler
+	Timeout            time.Duration
+	UseMinijail        bool
+	Verbose            bool
+	KeepColor          bool
+	LogOutput          io.Writer
 }
 
 func (options *RunnerOptions) ValidateOptions() error {
@@ -110,10 +110,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	args = append(args, r.EngineArgs...)
 
 	// Tell libfuzzer which corpus directory it should use
-	args = append(args, r.SeedsDir)
+	args = append(args, r.GeneratedCorpusDir)
 
-	// Add any additional corpus directories as further positional arguments
-	args = append(args, r.AdditionalSeedsDirs...)
+	// Add any seed corpus directories as further positional arguments
+	args = append(args, r.SeedCorpusDirs...)
 
 	if len(r.FuzzTargetArgs) > 0 {
 		// separate the libfuzzer and fuzz target arguments with a "--"
@@ -142,10 +142,10 @@ func (r *Runner) Run(ctx context.Context) error {
 			{Source: r.FuzzTarget},
 			// The first corpus directory must be writable, because
 			// libfuzzer writes new test inputs to it
-			{Source: r.SeedsDir, Writable: minijail.ReadWrite},
+			{Source: r.GeneratedCorpusDir, Writable: minijail.ReadWrite},
 		}
 
-		for _, dir := range r.AdditionalSeedsDirs {
+		for _, dir := range r.SeedCorpusDirs {
 			bindings = append(bindings, &minijail.Binding{Source: dir})
 		}
 


### PR DESCRIPTION
If a seed corpus directory was specified via --seeds-dir, we used to
use that as the first corpus directory passed to libFuzzer, causing
libFuzzer to write generated inputs into that directory. We decided that
we always want to store generated inputs in a fixed, non-configurable
directory instead, so we now pass the directories specified via
--seeds-dir as additional corpus directories to libFuzzer.