### PR TITLE
cmake: Fix for projects that don't enable the C language 

### DIFF
--- a/integration-tests/cmake/testdata/CMakeLists.txt
+++ b/integration-tests/cmake/testdata/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 
-project(CmakeTest)
+project(CmakeTest LANGUAGES CXX)
 
 enable_testing()
 

--- a/internal/cmd/init/init.go
+++ b/internal/cmd/init/init.go
@@ -69,7 +69,8 @@ func printBuildSystemInstructions(cwd string) {
 	}
 	if cfg.BuildSystem == config.BuildSystemCMake {
 		log.Infof(`
-Enable fuzz testing in your CMake project by adding the following lines to the top-level CMakeLists.txt:
+Enable fuzz testing in your CMake project by adding the following lines to the
+top-level CMakeLists.txt before any add_subdirectory(...) calls:
 
     find_package(cifuzz)
     enable_fuzz_testing()`)

--- a/tools/cmake/cifuzz/cmake/cifuzz-targets.cmake
+++ b/tools/cmake/cifuzz/cmake/cifuzz-targets.cmake
@@ -1,5 +1,12 @@
 add_library(cifuzz_internal_replayer STATIC EXCLUDE_FROM_ALL
             "${CMAKE_CURRENT_LIST_DIR}/../src/replayer.c")
+# If a CXX-only project depends on the replayer, it won't be able to compile and link the replayer's C source file.
+# Using enable_language(C) from a package is discouraged, but we can work around this by marking the replayer as a CXX
+# target if C is not enabled - it should build just fine with any C++ compiler.
+# https://discourse.cmake.org/t/is-it-appropriate-to-use-enable-language-in-a-cmake-package-file/4335/2
+if(NOT C IN_LIST ENABLED_LANGUAGES)
+  set_target_properties(cifuzz_internal_replayer PROPERTIES LINKER_LANGUAGE CXX)
+endif()
 if(CIFUZZ_SANITIZERS)
   target_compile_definitions(cifuzz_internal_replayer PRIVATE CIFUZZ_HAS_SANITIZER)
 endif()


### PR DESCRIPTION
Previously, projects with `project(MyProject LANGUAGES CXX)` in their
top-level CMakeLists.txt would fail to build the replayer.

This is fixed by marking replayer.c as a C++ source file if C is not
in ENABLED_LANGUAGES.