### PR TITLE
cifuzz.h: Suppress unused argument warning for FUZZ_TEST_SETUP

### DIFF
--- a/tools/cmake/cifuzz/include/cifuzz/cifuzz/cifuzz.h
+++ b/tools/cmake/cifuzz/include/cifuzz/cifuzz/cifuzz.h
@@ -78,6 +78,8 @@ void LLVMFuzzerTestOneInputNoReturn
 #define FUZZ_TEST_SETUP                                              \
 static void LLVMFuzzerInitializeNoReturn(void);                      \
 CIFUZZ_C_LINKAGE int LLVMFuzzerInitialize(int *argc, char ***argv) { \
+  (void) argc;                                                       \
+  (void) argv;                                                       \
   LLVMFuzzerInitializeNoReturn();                                    \
   return 0;                                                          \
 }                                                                    \


### PR DESCRIPTION
Fixes https://github.com/CodeIntelligenceTesting/cifuzz/issues/142