### PR TITLE
dialog: Don't ask for file path in dialogs

### DIFF
--- a/internal/cmd/bundle/bundle.go
+++ b/internal/cmd/bundle/bundle.go
@@ -17,7 +17,6 @@ import (
 	"code-intelligence.com/cifuzz/internal/completion"
 	"code-intelligence.com/cifuzz/internal/config"
 	"code-intelligence.com/cifuzz/pkg/artifact"
-	"code-intelligence.com/cifuzz/pkg/dialog"
 	"code-intelligence.com/cifuzz/pkg/log"
 	"code-intelligence.com/cifuzz/pkg/vcs"
 	"code-intelligence.com/cifuzz/util/fileutil"
@@ -99,19 +98,10 @@ func New(conf *config.Config) *cobra.Command {
 
 func (c *bundleCmd) run() (err error) {
 	if c.opts.outputPath == "" {
-		var defaultName string
 		if len(c.opts.fuzzTests) == 1 {
-			defaultName = c.opts.fuzzTests[0] + ".tar.gz"
+			c.opts.outputPath = c.opts.fuzzTests[0] + ".tar.gz"
 		} else {
-			defaultName = "fuzz_tests.tar.gz"
-		}
-		c.opts.outputPath, err = dialog.InputFilename(
-			c.InOrStdin(),
-			"Please enter the filename for the artifact (.tar.gz)",
-			defaultName,
-		)
-		if err != nil {
-			return err
+			c.opts.outputPath = "fuzz_tests.tar.gz"
 		}
 	}
 

--- a/internal/cmd/create/create.go
+++ b/internal/cmd/create/create.go
@@ -56,7 +56,7 @@ func run(cmd *cobra.Command, args []string, opts *cmdOpts) (err error) {
 	log.Debugf("Selected fuzz test type: %s", opts.testType)
 
 	if opts.outputPath == "" {
-		opts.outputPath, err = determineOutputPath(opts, cmd.InOrStdin())
+		opts.outputPath, err = stubs.FuzzTestFilename(opts.testType)
 		if err != nil {
 			return err
 		}
@@ -91,22 +91,6 @@ func getTestType(args []string, stdin io.Reader) (config.FuzzTestType, error) {
 		return "", cmdutils.ErrSilent
 	}
 	return config.FuzzTestType(userSelectedType), nil
-}
-
-func determineOutputPath(opts *cmdOpts, stdin io.Reader) (string, error) {
-	suggestedFilename, err := stubs.SuggestFilename(opts.testType)
-	if err != nil {
-		// as this error only results in a missing filename suggestion we just show
-		// it but do not stop the application
-		log.Errorf(err, "unable to suggest filename for given test type %s", opts.testType)
-	}
-
-	outputPath, err := dialog.InputFilename(stdin, "Please enter filename", suggestedFilename)
-	if err != nil {
-		return "", err
-	}
-
-	return outputPath, nil
 }
 
 func printBuildSystemInstructions(buildSystem, filename string) {

--- a/internal/cmd/create/create_test.go
+++ b/internal/cmd/create/create_test.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,26 +41,6 @@ func TestCreateCmd_InvalidType(t *testing.T) {
 	}
 	_, err := cmdutils.ExecuteCommand(t, New(config.NewConfig()), os.Stdin, args...)
 	assert.Error(t, err)
-}
-
-func TestCreateCmd_AskForOutputPath(t *testing.T) {
-	outputPath := filepath.Join(baseTempDir, "my_test_file.cpp")
-	input := []byte(strings.ReplaceAll(outputPath, "\\", "\\\\") + "\n")
-	r, w, err := os.Pipe()
-	assert.NoError(t, err)
-
-	_, err = w.Write(input)
-	assert.NoError(t, err)
-	w.Close()
-
-	args := []string{"cpp"}
-
-	_, err = cmdutils.ExecuteCommand(t, New(config.NewConfig()), r, args...)
-	assert.NoError(t, err)
-
-	exists, err := fileutil.Exists(outputPath)
-	assert.NoError(t, err)
-	assert.True(t, exists)
 }
 
 func TestCreateCmd_OutDir(t *testing.T) {

--- a/pkg/dialog/dialog.go
+++ b/pkg/dialog/dialog.go
@@ -1,17 +1,10 @@
 package dialog
 
 import (
-	"bufio"
-	"fmt"
 	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
-	"github.com/pterm/pterm"
 	"golang.org/x/exp/maps"
 
 	"code-intelligence.com/cifuzz/pkg/cmdutils"
@@ -33,94 +26,4 @@ func Select(message string, items map[string]string, inReader io.Reader) (string
 	}
 
 	return items[result], nil
-}
-
-// InputFilename reads a filename from stdin, with tab-completion if
-// available in the current shell
-func InputFilename(reader io.Reader, message string, defaultValue string) (string, error) {
-	// Print the message
-	if defaultValue == "" {
-		fmt.Printf("%s: \n", message)
-	} else {
-		fmt.Printf("%s [%s]: \n", message, defaultValue)
-	}
-
-	return readFilenameWithShellCompletion(reader, defaultValue)
-}
-
-func readline(reader io.Reader, defaultValue string) (string, error) {
-	input, err := bufio.NewReader(reader).ReadString('\n')
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	input = strings.ReplaceAll(input, "\n", "")
-
-	if input == "" {
-		return defaultValue, nil
-	}
-	return input, nil
-}
-
-var shellCompletionArgs = map[string][]string{
-	"bash": {"-c", "read -e && echo \"${REPLY}\" >&3"},
-	"zsh":  {"-i", "-c", "vared -c REPLY && echo \"${REPLY}\" >&3"},
-}
-
-func readFilenameWithShellCompletion(reader io.Reader, defaultValue string) (string, error) {
-	shellAbsPath, err := exec.LookPath(os.Getenv("SHELL"))
-	if errors.Is(err, exec.ErrNotFound) {
-		// Shell not found, fall back to reading without completion support.
-		return readline(reader, defaultValue)
-	}
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	shellName := filepath.Base(shellAbsPath)
-	completionArgs, supported := shellCompletionArgs[shellName]
-	if !supported {
-		// Shell not supported, fall back to reading without completion support.
-		return readline(reader, defaultValue)
-	}
-
-	// The shell which we start in a subprocess might write output to
-	// stdout (for example when it executes the .bashrc or .zshrc), so
-	// we can't use stdout to pass the user input. Instead, we create a
-	// pipe which we pass as fd 3 which the subprocess then uses to
-	// pass the user input.
-	r, w, err := os.Pipe()
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	cmd := exec.Command(shellAbsPath, completionArgs...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = reader
-	// Pass the pipe as fd 3
-	cmd.ExtraFiles = []*os.File{w}
-	err = cmd.Run()
-	if _, ok := err.(*exec.ExitError); ok {
-		// Fail silently in this case, which includes the user hitting Ctrl + C.
-		return "", cmdutils.WrapSilentError(errors.WithStack(err))
-	}
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	// Close the write end of the pipe
-	err = w.Close()
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	// Read the user input written to the pipe
-	out, err := io.ReadAll(r)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	input := strings.TrimSpace(pterm.RemoveColorFromString(string(out)))
-
-	if input == "" {
-		return defaultValue, nil
-	}
-	return input, nil
 }

--- a/pkg/dialog/dialog_test.go
+++ b/pkg/dialog/dialog_test.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,51 +25,4 @@ func TestSelect(t *testing.T) {
 	userInput, err := Select("Test", items, r)
 	assert.NoError(t, err)
 	assert.Equal(t, "item1", userInput)
-}
-
-func TestInputFilename(t *testing.T) {
-	input := []byte("my input\n")
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-
-	_, err = w.Write(input)
-	require.NoError(t, err)
-	w.Close()
-
-	// The zsh vared command we're using when the current shell is zsh
-	// uses /dev/tty for reading instead of stdin, which causes this
-	// test to block. To avoid that, we're unsetting the SHELL variable
-	// in that case to make InputFilename fall back to just reading a
-	// line from stdin.
-	if filepath.Base(os.Getenv("SHELL")) == "zsh" {
-		_ = os.Unsetenv("SHELL")
-	}
-
-	userInput, err := InputFilename(r, "Test", "default")
-	assert.NoError(t, err)
-	assert.Equal(t, "my input", userInput)
-}
-
-// Should return default value if user just presses "enter"
-func TestInputFilename_Default(t *testing.T) {
-	input := []byte("\n")
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-
-	_, err = w.Write(input)
-	require.NoError(t, err)
-	w.Close()
-
-	// The zsh vared command we're using when the current shell is zsh
-	// uses /dev/tty for reading instead of stdin, which causes this
-	// test to block. To avoid that, we're unsetting the SHELL variable
-	// in that case to make InputFilename fall back to just reading a
-	// line from stdin.
-	if filepath.Base(os.Getenv("SHELL")) == "zsh" {
-		_ = os.Unsetenv("SHELL")
-	}
-
-	userInput, err := InputFilename(r, "Test", "default")
-	assert.NoError(t, err)
-	assert.Equal(t, "default", userInput)
 }

--- a/pkg/stubs/stubs.go
+++ b/pkg/stubs/stubs.go
@@ -41,9 +41,9 @@ func Create(path string, testType config.FuzzTestType) error {
 	return nil
 }
 
-// SuggestFilename returns a proposal for a filename,
+// FuzzTestFilename returns a proposal for a filename,
 // depending on the test type and given directory
-func SuggestFilename(testType config.FuzzTestType) (string, error) {
+func FuzzTestFilename(testType config.FuzzTestType) (string, error) {
 	var basename, ext, filename string
 
 	switch testType {

--- a/pkg/stubs/stubs_test.go
+++ b/pkg/stubs/stubs_test.go
@@ -71,14 +71,14 @@ func TestSuggestFilename(t *testing.T) {
 	err = os.Chdir(projectDir)
 	require.NoError(t, err)
 
-	filename1, err := SuggestFilename(config.CPP)
+	filename1, err := FuzzTestFilename(config.CPP)
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(".", "my_fuzz_test_1.cpp"), filename1)
 
 	err = os.WriteFile(filename1, []byte("TEST"), 0644)
 	require.NoError(t, err)
 
-	filename2, err := SuggestFilename(config.CPP)
+	filename2, err := FuzzTestFilename(config.CPP)
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(".", "my_fuzz_test_2.cpp"), filename2)
 }


### PR DESCRIPTION
Use a default path instead. This reduces unnecessary complexity,
including having to test the shell completion support with different
shells. We also found that there is no popular tool which asks for the
path where it creates a file in a dialog.