### PR TITLE
Use viper to read cifuzz.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp/
 bin/
 lib/
 scratch/
+.installer-lock
 
 coverage.out
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,6 +1,131 @@
-# Project configuration
-The project specific configuration is stored in the `cifuzz.yaml`. This is an overview of the available options:
-```
+# cifuzz configuration
+You can change the behavior of **cifuzz** both via command-line flags
+and via settings stored in the `cifuzz.yaml` config file. Flags take
+precedence over the respective config file setting.
+
+## cifuzz.yaml settings
+
+[build-system](#build-system) <br/>
+[build-command](#build-command) <br/>
+[seed-corpus-dirs](#seed-corpus-dirs) <br/>
+[dict](#dict) <br/>
+[engine-args](#engine-args) <br/>
+[fuzz-test-args](#fuzz-test-args) <br/>
+[timeout](#timeout) <br/>
+[use-sandbox](#use-sandbox) <br/>
+[print-json](#print-json) <br/>
+
+<a id="build-system"></a>
+
+### build-system
+
+The build system used to build this project. If not set, cifuzz tries
+to detect the build system automatically.
+Valid values: "cmake", "unknown".
+
+#### Example
+
+```yaml
+build-system: cmake
 ```
 
+<a id="build-command"></a>
 
+### build-command
+
+If the build system type is "unknown", this command is used by
+`cifuzz run` to build the fuzz test.
+
+#### Example
+
+```yaml
+build-command: "make all"
+```
+
+<a id="seed-corpus-dirs"></a>
+
+### seed-corpus-dirs
+
+Directories containing sample inputs for the code under test.
+See https://llvm.org/docs/LibFuzzer.html#corpus and
+https://aflplus.plus/docs/fuzzing_in_depth/#a-collecting-inputs.
+
+#### Example
+
+```yaml
+seed-corpus-dirs:
+ - path/to/seed-corpus
+```
+
+<a id="dict"></a>
+
+### dict
+
+A file containing input language keywords or other interesting byte
+sequences. See https://llvm.org/docs/LibFuzzer.html#dictionaries and
+https://github.com/AFLplusplus/AFLplusplus/blob/stable/dictionaries/README.md.
+
+#### Example
+```yaml
+dict: path/to/dictionary.dct
+```
+
+<a id="engine-args"></a>
+
+### engine-args
+Command-line arguments to pass to the fuzzing engine (libFuzzer or
+AFL++). See https://llvm.org/docs/LibFuzzer.html#options and
+https://www.mankier.com/8/afl-fuzz.
+
+#### Example
+```yaml
+engine-args:
+ - -rss_limit_mb=4096
+```
+
+<a id="fuzz-test-args"></a>
+
+### fuzz-test-args
+Command-line arguments to pass to the fuzz tests.
+
+#### Example
+```yaml
+fuzz-test-args:
+ - --config-file=path/to/config
+```
+
+<a id="timeout"></a>
+
+### timeout
+
+Maximum time in seconds to run the fuzz tests. The default is to run
+indefinitely.
+
+#### Example
+```yaml
+timeout: 300
+```
+
+<a id="use-sandbox"></a>
+
+### use-sandbox
+
+By default, fuzz tests are executed in a sandbox to prevent accidental
+damage to the system. Set to false to run fuzz tests unsandboxed.
+Only supported on Linux.
+
+#### Example
+```yaml
+use-sandbox: false
+```
+
+<a id="print-json"></a>
+
+### print-json
+
+Set to true to print output of the `cifuzz run` command as JSON.
+
+#### Example
+```yaml
+print-json: true
+```

--- a/examples/cmake/cifuzz.yaml
+++ b/examples/cmake/cifuzz.yaml
@@ -1,7 +1,7 @@
 ## Configuration for a CI Fuzz project
-## Generated on 2022-06-15
+## Generated on 2022-07-14
 
-## The build system used to build this project. If set to "auto" (the
-## default), cifuzz tries to detect the build system automatically.
-## Valid values: "auto", "cmake", "unknown".
-#build-system: auto
+## The build system used to build this project. If not set, cifuzz tries
+## to detect the build system automatically.
+## Valid values: "cmake", "unknown".
+#build-system: cmake

--- a/examples/cmake/cifuzz.yaml
+++ b/examples/cmake/cifuzz.yaml
@@ -4,4 +4,4 @@
 ## The build system used to build this project. If set to "auto" (the
 ## default), cifuzz tries to detect the build system automatically.
 ## Valid values: "auto", "cmake", "unknown".
-#build_system: auto
+#build-system: auto

--- a/integration-tests/cmake/cmake_test.go
+++ b/integration-tests/cmake/cmake_test.go
@@ -94,6 +94,12 @@ func TestIntegration_InitCreateRunBundle(t *testing.T) {
 	// Run the fuzz test
 	runFuzzer(t, cifuzz, dir, regexp.MustCompile(`^==\d*==ERROR: AddressSanitizer: heap-use-after-free`), false)
 
+	// Check that options set via the config file are respected
+	configFileContent := `engine-args:
+ - -rss_limit_mb=1234`
+	err = os.WriteFile(filepath.Join(dir, "cifuzz.yaml"), []byte(configFileContent), 0644)
+	runFuzzer(t, cifuzz, dir, regexp.MustCompile(`-rss_limit_mb=1234`), false)
+
 	// Run cifuzz bundle and verify the contents of the archive.
 	archiveDir := createAndExtractArtifactArchive(t, dir, cifuzz)
 	defer fileutil.Cleanup(archiveDir)

--- a/internal/cmd/init/init.go
+++ b/internal/cmd/init/init.go
@@ -20,7 +20,7 @@ func New() *cobra.Command {
 		Use:   "init",
 		Short: "Set up a project for use with cifuzz",
 		Long: "This command sets up a project for use with cifuzz, creating a " +
-			"`.cifuzz.yaml` config file.",
+			"`cifuzz.yaml` config file.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd, args, opts)

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -82,7 +82,7 @@ func New() (*cobra.Command, error) {
 
 	rootCmd.AddCommand(initCmd.New())
 	rootCmd.AddCommand(createCmd.New(cmdConfig))
-	rootCmd.AddCommand(runCmd.New(cmdConfig))
+	rootCmd.AddCommand(runCmd.New())
 	rootCmd.AddCommand(reloadCmd.New())
 	rootCmd.AddCommand(bundleCmd.New(cmdConfig))
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -36,7 +36,7 @@ type runOptions struct {
 	seedCorpusDirs []string
 	dictionary     string
 	engineArgs     []string
-	fuzzTargetArgs []string
+	fuzzTestArgs   []string
 	timeout        time.Duration
 	useSandbox     bool
 	printJSON      bool
@@ -112,7 +112,7 @@ func New(config *config.Config) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&opts.seedCorpusDirs, "seed-corpus", "s", nil, "Directory containing sample inputs for the code under test.\nSee https://llvm.org/docs/LibFuzzer.html#corpus and\nhttps://aflplus.plus/docs/fuzzing_in_depth/#a-collecting-inputs.")
 	cmd.Flags().StringVar(&opts.dictionary, "dict", "", "A file containing input language keywords or other interesting byte sequences.\nSee https://llvm.org/docs/LibFuzzer.html#dictionaries and\nhttps://github.com/AFLplusplus/AFLplusplus/blob/stable/dictionaries/README.md.")
 	cmd.Flags().StringArrayVar(&opts.engineArgs, "engine-arg", nil, "Command-line argument to pass to the fuzzing engine.\nSee https://llvm.org/docs/LibFuzzer.html#options and\nhttps://www.mankier.com/8/afl-fuzz.")
-	cmd.Flags().StringArrayVar(&opts.fuzzTargetArgs, "fuzz-test-arg", nil, "Command-line argument to pass to the fuzz test.")
+	cmd.Flags().StringArrayVar(&opts.fuzzTestArgs, "fuzz-test-arg", nil, "Command-line argument to pass to the fuzz test.")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 0, "Maximum time in seconds to run the fuzz test. The default is to run indefinitely.")
 	useMinijailDefault := runtime.GOOS == "linux"
 	cmd.Flags().BoolVar(&opts.useSandbox, "use-sandbox", useMinijailDefault, "By default, fuzz tests are executed in a sandbox to prevent accidental damage to the system.\nUse --sandbox=false to run the fuzz test unsandboxed.\nOnly supported on Linux.")
@@ -244,7 +244,7 @@ func (c *runCmd) runFuzzTest(fuzzTestExecutable string) error {
 		SeedCorpusDirs:     c.opts.seedCorpusDirs,
 		Dictionary:         c.opts.dictionary,
 		EngineArgs:         c.opts.engineArgs,
-		FuzzTargetArgs:     c.opts.fuzzTargetArgs,
+		FuzzTestArgs:       c.opts.fuzzTestArgs,
 		ReportHandler:      c.reportHandler,
 		Timeout:            c.opts.timeout,
 		UseMinijail:        c.opts.useSandbox,

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -115,7 +115,7 @@ func New(config *config.Config) *cobra.Command {
 	cmd.Flags().StringArrayVar(&opts.fuzzTargetArgs, "fuzz-test-arg", nil, "Command-line argument to pass to the fuzz test.")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 0, "Maximum time in seconds to run the fuzz test. The default is to run indefinitely.")
 	useMinijailDefault := runtime.GOOS == "linux"
-	cmd.Flags().BoolVar(&opts.useSandbox, "sandbox", useMinijailDefault, "By default, fuzz tests are executed in a sandbox to prevent accidental damage to the system.\nUse --sandbox=false to run the fuzz test unsandboxed.\nOnly supported on Linux.")
+	cmd.Flags().BoolVar(&opts.useSandbox, "use-sandbox", useMinijailDefault, "By default, fuzz tests are executed in a sandbox to prevent accidental damage to the system.\nUse --sandbox=false to run the fuzz test unsandboxed.\nOnly supported on Linux.")
 	cmd.Flags().BoolVar(&opts.printJSON, "json", false, "Print output as JSON")
 
 	return cmd

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -75,7 +75,7 @@ func (opts *runOptions) validate() error {
 		}
 	}
 
-	if opts.BuildSystem == "" || opts.BuildSystem == config.BuildSystemAuto {
+	if opts.BuildSystem == "" {
 		opts.BuildSystem, err = config.DetermineBuildSystem(opts.ProjectDir)
 		if err != nil {
 			return err

--- a/internal/cmd/run/run_test.go
+++ b/internal/cmd/run/run_test.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"code-intelligence.com/cifuzz/internal/config"
 	"code-intelligence.com/cifuzz/pkg/cmdutils"
 )
 
 func TestRunCmd(t *testing.T) {
-	_, err := cmdutils.ExecuteCommand(t, New(config.NewConfig()), os.Stdin)
+	_, err := cmdutils.ExecuteCommand(t, New(), os.Stdin)
 	assert.Error(t, err)
 }

--- a/internal/config/cifuzz.yaml.tmpl
+++ b/internal/config/cifuzz.yaml.tmpl
@@ -1,10 +1,10 @@
 ## Configuration for a CI Fuzz project
 ## Generated on {{.LastUpdated}}
 
-## The build system used to build this project. If set to "auto" (the
-## default), cifuzz tries to detect the build system automatically.
-## Valid values: "auto", "cmake", "unknown".
-#build-system: auto
+## The build system used to build this project. If not set, cifuzz tries
+## to detect the build system automatically.
+## Valid values: "cmake", "unknown".
+#build-system: cmake
 
 ## If the build system type is "unknown", this command is used by
 ## `cifuzz run` to build the fuzz test.

--- a/internal/config/cifuzz.yaml.tmpl
+++ b/internal/config/cifuzz.yaml.tmpl
@@ -4,4 +4,41 @@
 ## The build system used to build this project. If set to "auto" (the
 ## default), cifuzz tries to detect the build system automatically.
 ## Valid values: "auto", "cmake", "unknown".
-#build_system: auto
+#build-system: auto
+
+## If the build system type is "unknown", this command is used by
+## `cifuzz run` to build the fuzz test.
+#build-command: "make my_fuzz_test"
+
+## Directories containing sample inputs for the code under test.
+## See https://llvm.org/docs/LibFuzzer.html#corpus and
+## https://aflplus.plus/docs/fuzzing_in_depth/#a-collecting-inputs.
+#seed-corpus-dirs:
+# - path/to/seed-corpus
+
+## A file containing input language keywords or other interesting byte
+## sequences. See https://llvm.org/docs/LibFuzzer.html#dictionaries and
+## https://github.com/AFLplusplus/AFLplusplus/blob/stable/dictionaries/README.md.
+#dict: path/to/dictionary.dct
+
+## Command-line arguments to pass to the fuzzing engine (libFuzzer or
+## AFL++). See https://llvm.org/docs/LibFuzzer.html#options and
+## https://www.mankier.com/8/afl-fuzz.
+#engine-args:
+# - -rss_limit_mb=4096
+
+## Command-line arguments to pass to the fuzz tests.
+#fuzz-test-args:
+# - --config-file=path/to/config
+
+## Maximum time in seconds to run the fuzz tests. The default is to run
+## indefinitely.
+#timeout: 300
+
+## By default, fuzz tests are executed in a sandbox to prevent accidental
+## damage to the system. Set to false to run fuzz tests unsandboxed.
+## Only supported on Linux.
+#use-sandbox: false
+
+## Set to true to print output of the `cifuzz run` command as JSON.
+#print-json: true

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	BuildSystemAuto    string = "auto"
 	BuildSystemCMake   string = "cmake"
 	BuildSystemUnknown string = "unknown"
 )
@@ -109,7 +108,7 @@ func ReadProjectConfig(projectDir string) (*ProjectConfig, error) {
 		BuildSystem: viper.GetString("build-system"),
 	}
 
-	if config.BuildSystem == "" || config.BuildSystem == BuildSystemAuto {
+	if config.BuildSystem == "" {
 		config.BuildSystem, err = DetermineBuildSystem(projectDir)
 		if err != nil {
 			return nil, err

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -93,7 +93,7 @@ func TestReadProjectConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	configFile := filepath.Join(projectDir, "cifuzz.yaml")
-	err = os.WriteFile(configFile, []byte("build_system: "+BuildSystemAuto), 0644)
+	err = os.WriteFile(configFile, []byte("build_system: "), 0644)
 	require.NoError(t, err)
 
 	config, err := ReadProjectConfig(projectDir)
@@ -107,7 +107,7 @@ func TestReadProjectConfigCMake(t *testing.T) {
 	require.NoError(t, err)
 
 	configFile := filepath.Join(projectDir, "cifuzz.yaml")
-	err = os.WriteFile(configFile, []byte("build_system: "+BuildSystemAuto), 0644)
+	err = os.WriteFile(configFile, []byte("build_system: "), 0644)
 	require.NoError(t, err)
 
 	// Create a CMakeLists.txt in the project dir, which should cause

--- a/pkg/cmdutils/pflag.go
+++ b/pkg/cmdutils/pflag.go
@@ -1,6 +1,10 @@
 package cmdutils
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
 
 func MarkFlagsRequired(cmd *cobra.Command, flags ...string) {
 	for _, flag := range flags {
@@ -8,5 +12,12 @@ func MarkFlagsRequired(cmd *cobra.Command, flags ...string) {
 		if err != nil {
 			panic(err)
 		}
+	}
+}
+
+func ViperMustBindPFlag(key string, flag *pflag.Flag) {
+	err := viper.BindPFlag(key, flag)
+	if err != nil {
+		panic(err)
 	}
 }

--- a/pkg/runner/jazzer/jazzer_runner.go
+++ b/pkg/runner/jazzer/jazzer_runner.go
@@ -116,11 +116,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	// -----------------------------
 	// --- fuzz target arguments ---
 	// -----------------------------
-	if len(r.FuzzTargetArgs) > 0 {
-		// separate the Jazzer/libfuzzer arguments and fuzz target
+	if len(r.FuzzTestArgs) > 0 {
+		// separate the Jazzer/libfuzzer arguments and fuzz test
 		// arguments with a "--"
 		args = append(args, "--")
-		args = append(args, r.FuzzTargetArgs...)
+		args = append(args, r.FuzzTestArgs...)
 	}
 	// -----------------------------
 

--- a/pkg/runner/libfuzzer/integration-tests/runner_testutils.go
+++ b/pkg/runner/libfuzzer/integration-tests/runner_testutils.go
@@ -43,7 +43,7 @@ type RunnerTest struct {
 	GeneratedCorpusDir string
 	Timeout            time.Duration
 	EngineArgs         []string
-	FuzzTargetArgs     []string
+	FuzzTestArgs       []string
 	FuzzerEnv          []string
 	DisableMinijail    bool
 	RunsLimit          int
@@ -89,7 +89,7 @@ func (test *RunnerTest) Start(t *testing.T, reportCh chan *report.Report) error 
 		SeedCorpusDirs:     []string{seedCorpusDir},
 		Timeout:            test.Timeout,
 		EngineArgs:         test.EngineArgs,
-		FuzzTargetArgs:     test.FuzzTargetArgs,
+		FuzzTestArgs:       test.FuzzTestArgs,
 		EnvVars:            test.FuzzerEnv,
 		UseMinijail:        !test.DisableMinijail,
 		ReportHandler:      &ChannelPassthrough{ch: reportCh},

--- a/pkg/runner/libfuzzer/libfuzzer_runner.go
+++ b/pkg/runner/libfuzzer/libfuzzer_runner.go
@@ -43,7 +43,7 @@ type RunnerOptions struct {
 	LibraryDirs        []string
 	EnvVars            []string
 	EngineArgs         []string
-	FuzzTargetArgs     []string
+	FuzzTestArgs       []string
 	ReportHandler      report.Handler
 	Timeout            time.Duration
 	UseMinijail        bool
@@ -115,10 +115,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	// Add any seed corpus directories as further positional arguments
 	args = append(args, r.SeedCorpusDirs...)
 
-	if len(r.FuzzTargetArgs) > 0 {
-		// separate the libfuzzer and fuzz target arguments with a "--"
+	if len(r.FuzzTestArgs) > 0 {
+		// separate the libfuzzer and fuzz test arguments with a "--"
 		args = append(args, "--")
-		args = append(args, r.FuzzTargetArgs...)
+		args = append(args, r.FuzzTestArgs...)
 	}
 
 	// The environment to run libfuzzer in


### PR DESCRIPTION
This uses viper to read the config file and set the command options
according to the settings in the config file. The commit also merges
the old project config into the command options struct, because the only
setting of the project config, the build system setting, can just as
well be a command option (and should also be configurable via a
command-line flag - that will be done in a follow-up commit).

Using viper allows us to handle configuration with very little
self-maintained code. What motivated me to make this change is the
viper.SetDefault() function, which allows us to set a default value
which is applied when neither the config file setting nor the flag is set,
a functionality that we would have reimplement otherwise.
