### PR TITLE
integration-tests: Limit runs rather than time

### DIFF
--- a/integration-tests/cmake/cmake_test.go
+++ b/integration-tests/cmake/cmake_test.go
@@ -119,10 +119,15 @@ func copyTestdataDir(t *testing.T) string {
 func runFuzzer(t *testing.T, cifuzz string, dir string, expectedOutput *regexp.Regexp, terminate bool) {
 	t.Helper()
 
-	const timeout = 5 * time.Minute
-	runCtx, closeRunCtx := context.WithTimeout(context.Background(), timeout)
+	runCtx, closeRunCtx := context.WithCancel(context.Background())
 	defer closeRunCtx()
-	cmd := executil.CommandContext(runCtx, cifuzz, "run", "-v", "parser_fuzz_test", "--engine-arg=-seed=1")
+	cmd := executil.CommandContext(
+		runCtx,
+		cifuzz,
+		"run", "-v", "parser_fuzz_test",
+		"--engine-arg=-seed=1",
+		"--engine-arg=-runs=1000000",
+	)
 	cmd.Dir = dir
 	stdoutPipe, err := cmd.StdoutTeePipe(os.Stdout)
 	require.NoError(t, err)


### PR DESCRIPTION
Limiting runs rather than time should be less flaky and also provide
faster test failures in case of breakages.

The value of 1,000,000 runs is 5x as high as the maximum runs count
found in CI logs across the three platforms.