### PR TITLE
util: Don't fail when trying to kill an already terminated process

### DIFF
--- a/util/executil/executil_unix.go
+++ b/util/executil/executil_unix.go
@@ -19,10 +19,7 @@ func (c *Cmd) TerminateProcessGroup() error {
 	log.Infof("Sending SIGTERM to process group %d", c.pgid)
 	// We ignore errors here because the process group might not exist
 	// anymore at this point.
-	err := syscall.Kill(-c.pgid, syscall.SIGTERM) // note the minus sign
-	if err != nil {
-		return errors.WithStack(err)
-	}
+	_ = syscall.Kill(-c.pgid, syscall.SIGTERM) // note the minus sign
 
 	// Give the process group a few seconds to exit
 	select {
@@ -32,10 +29,7 @@ func (c *Cmd) TerminateProcessGroup() error {
 		log.Infof("Sending SIGKILL to process group %d", c.pgid)
 		// We ignore errors here because the process group might not exist
 		// anymore at this point.
-		err = syscall.Kill(-c.pgid, syscall.SIGKILL) // note the minus sign
-		if err != nil {
-			return errors.WithStack(err)
-		}
+		_ = syscall.Kill(-c.pgid, syscall.SIGKILL) // note the minus sign
 	case <-c.waitDone:
 		// The process has already exited, nothing else to do here.
 		// Note: This might leave other processes in the process group

--- a/util/executil/executil_windows.go
+++ b/util/executil/executil_windows.go
@@ -15,6 +15,11 @@ func (c *Cmd) TerminateProcessGroup() error {
 	kill.Stderr = os.Stderr
 	kill.Stdout = os.Stderr
 	err := kill.Run()
+	// taskkill can fail e.g. because the process has already been terminated.
+	// We only report non-ExitErrors.
+	if _, isExitErr := err.(*exec.ExitError); isExitErr {
+		return nil
+	}
 	return errors.WithStack(err)
 }
 


### PR DESCRIPTION
Fix for the following test failure seen in CI:

```
SUCCESS: The process with PID 3924 (child process of PID 5020) has been terminated.
SUCCESS: The process with PID 5020 (child process of PID 2564) has been terminated.
ERROR: The process "5020" not found.
    cmake_test.go:86:
        	Error Trace:	D:\a\cifuzz\cifuzz\integration-tests\cmake\cmake_test.go:163
        	            				D:\a\cifuzz\cifuzz\integration-tests\cmake\cmake_test.go:86
        	Error:      	Received unexpected error:
        	            	exit status 128
        	            	code-intelligence.com/cifuzz/util/executil.(*Cmd).TerminateProcessGroup
        	            		D:/a/cifuzz/cifuzz/util/executil/executil_windows.go:18
        	            	code-intelligence.com/cifuzz/integration-tests/cmake.runFuzzer
        	            		D:/a/cifuzz/cifuzz/integration-tests/cmake/cmake_test.go:162
        	            	code-intelligence.com/cifuzz/integration-tests/cmake.TestIntegration_InitCreateRunBundle
        	            		D:/a/cifuzz/cifuzz/integration-tests/cmake/cmake_test.go:86
        	            	testing.tRunner
        	            		C:/hostedtoolcache/windows/go/1.18.3/x64/src/testing/testing.go:1439
        	            	runtime.goexit
        	            		C:/hostedtoolcache/windows/go/1.18.3/x64/src/runtime/asm_amd64.s:1571
        	Test:       	TestIntegration_InitCreateRunBundle
```