### PR TITLE
parser: Refactor away error-prone err == nil check

### DIFF
--- a/pkg/parser/libfuzzer/libfuzzer_parser.go
+++ b/pkg/parser/libfuzzer/libfuzzer_parser.go
@@ -156,8 +156,7 @@ func (p *parser) parseLine(ctx context.Context, line string) error {
 					return errors.WithStack(err)
 				}
 			}
-		}
-		if err == nil {
+		} else {
 			p.initStarted = true
 
 			if numSeeds == 0 {


### PR DESCRIPTION
As a follow-up to #166, this commit gets rid of an err == nil check that
made it important to not accidentally overwrite the value of err in the
err != nil branch.