### PR TITLE
cmake: Represent coverage builds as a combination of engine and sanitizer

### DIFF
--- a/integration-tests/cmake/cmake_test.go
+++ b/integration-tests/cmake/cmake_test.go
@@ -374,7 +374,7 @@ func runArchivedFuzzer(t *testing.T, archiveDir string) {
 		return
 	}
 	// Verify that a coverage build has been added to the archive.
-	fuzzerPathPattern = regexp.MustCompile(`\W*path: (coverage.*parser_fuzz_test.*)`)
+	fuzzerPathPattern = regexp.MustCompile(`\W*path: (replayer/coverage.*parser_fuzz_test.*)`)
 	fuzzerPath = filepath.Join(archiveDir, string(fuzzerPathPattern.FindSubmatch(metadataYaml)[1]))
 	require.FileExists(t, fuzzerPath)
 

--- a/internal/cmd/bundle/bundle.go
+++ b/internal/cmd/bundle/bundle.go
@@ -233,7 +233,8 @@ func (c *bundleCmd) buildAllVariants() ([]builderAndFuzzTests, error) {
 	// Coverage builds are not supported by MSVC.
 	if runtime.GOOS != "windows" {
 		coverageVariant := configureVariant{
-			Engine: "coverage",
+			Engine:     "replayer",
+			Sanitizers: []string{"coverage"},
 		}
 		configureVariants = append(configureVariants, coverageVariant)
 	}
@@ -252,7 +253,7 @@ func (c *bundleCmd) buildAllVariants() ([]builderAndFuzzTests, error) {
 		}
 
 		var typeDisplayString string
-		if variant.Engine == "coverage" {
+		if variant.Engine == "replayer" {
 			typeDisplayString = "coverage"
 		} else {
 			typeDisplayString = "fuzzing"
@@ -410,7 +411,7 @@ depsLoop:
 		LibraryPaths: externalLibrariesPrefix,
 	}
 
-	if builder.Opts().Engine == "coverage" {
+	if builder.Opts().Engine == "replayer" {
 		fuzzer := baseFuzzerInfo
 		fuzzer.Engine = "LLVM_COV"
 		fuzzers = []*artifact.Fuzzer{&fuzzer}


### PR DESCRIPTION
Makes it more clear that coverage builds essentially just use the
replayer (albeit with a few more, technical flags) and apply coverage
instrumentation.