### PR TITLE
added error checking for ftell result

### DIFF
--- a/tools/replayer/replayer_test.go
+++ b/tools/replayer/replayer_test.go
@@ -79,6 +79,7 @@ var clang = compilerCase{
 		"-Wall",
 		"-Wextra",
 		"-Werror",
+		"-Wconversion",
 		// Add debug info to make ASan and UBSan findings more useful.
 		"-g",
 		"-fsanitize=address,undefined",
@@ -100,6 +101,7 @@ var mingw = compilerCase{
 	[]string{
 		"-Wall",
 		"-Wextra",
+		"-Wconversion",
 		"-pedantic",
 		"-pedantic-errors",
 		"-Werror",

--- a/tools/replayer/src/replayer.c
+++ b/tools/replayer/src/replayer.c
@@ -248,6 +248,7 @@ static void run_file(const char *path) {
   size_t len;
   unsigned char *buf;
   size_t n_read;
+  long pos;
 
   fprintf(stderr, "Running: %s\n", path);
 #ifdef _WIN32
@@ -262,7 +263,12 @@ static void run_file(const char *path) {
     exit(1);
   }
   fseek(f, 0, SEEK_END);
-  len = ftell(f);
+  pos = ftell(f);
+  if (pos < 0) {
+    perror("File is not seekable");
+    exit(1);
+  }
+  len = (size_t) pos;
   fseek(f, 0, SEEK_SET);
   buf = (unsigned char*)malloc(len);
   assert(buf != NULL);


### PR DESCRIPTION
will resolve compiler `-Wsign-conversion` warning and prevent `malloc(-1)` if `run_file` is called on a non-seekable file like `/dev/stdin`.