### PR TITLE
fix(jazzer): exclude maven and gradle classes from being instrumented

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -551,10 +551,12 @@ func (c *runCmd) runFuzzTest(buildResult *build.Result) error {
 	case config.BuildSystemCMake, config.BuildSystemBazel, config.BuildSystemOther:
 		runner = libfuzzer.NewRunner(runnerOpts)
 	case config.BuildSystemMaven, config.BuildSystemGradle:
+		excludePatterns := []string{"org.apache.maven.**", "org.gradle.**"}
 		runnerOpts := &jazzer.RunnerOptions{
-			TargetClass:      c.opts.fuzzTest,
-			ClassPaths:       buildResult.RuntimeDeps,
-			LibfuzzerOptions: runnerOpts,
+			TargetClass:             c.opts.fuzzTest,
+			ClassPaths:              buildResult.RuntimeDeps,
+			InstrumentationExcludes: excludePatterns,
+			LibfuzzerOptions:        runnerOpts,
 		}
 		runner = jazzer.NewRunner(runnerOpts)
 	}

--- a/pkg/runner/jazzer/jazzer_runner.go
+++ b/pkg/runner/jazzer/jazzer_runner.go
@@ -25,11 +25,11 @@ var customHooks = []string{
 }
 
 type RunnerOptions struct {
-	LibfuzzerOptions              *libfuzzer.RunnerOptions
-	AutofuzzTarget                string
-	TargetClass                   string
-	ClassPaths                    []string
-	InstrumentationPackageFilters []string
+	LibfuzzerOptions        *libfuzzer.RunnerOptions
+	AutofuzzTarget          string
+	TargetClass             string
+	ClassPaths              []string
+	InstrumentationExcludes []string
 }
 
 func (options *RunnerOptions) ValidateOptions() error {
@@ -90,6 +90,13 @@ func (r *Runner) Run(ctx context.Context) error {
 	} else {
 		args = append(args, "--target_class="+r.TargetClass)
 	}
+
+	if len(r.InstrumentationExcludes) > 0 {
+		// Exclude specific classes from being instrumented for fuzzing
+		excludes := strings.Join(r.InstrumentationExcludes, string(os.PathListSeparator))
+		args = append(args, "--instrumentation_excludes="+excludes)
+	}
+
 	// -------------------------
 	// --- libfuzzer options ---
 	// -------------------------


### PR DESCRIPTION
Exclude maven and gradle classes from being instrumented for fuzzing.

### Motivation & Context
A user reported failing fuzz tests for which jazzer crashed in internal gradle classes.
