### PR TITLE
Gradle Integration: Do not attempt to call 'gradle testClasses'

### DIFF
--- a/internal/build/gradle/gradle.go
+++ b/internal/build/gradle/gradle.go
@@ -92,18 +92,6 @@ func (b *Builder) Build(targetClass string) (*build.Result, error) {
 		flags = append(flags, "--parallel")
 	}
 
-	args := append([]string{"testClasses"}, flags...)
-	cmd, err := buildGradleCommand(b.ProjectDir, args)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Debugf("Command: %s", cmd.String())
-	_, err = cmd.Output()
-	if err != nil {
-		return nil, cmdutils.WrapExecError(errors.WithStack(err), cmd)
-	}
-
 	deps, err := b.getDependencies()
 	if err != nil {
 		return nil, err
@@ -142,7 +130,7 @@ func (b *Builder) GradlePluginVersion() (string, error) {
 }
 
 func (b *Builder) getDependencies() ([]string, error) {
-	cmd, err := buildGradleCommand(b.ProjectDir, []string{"cifuzzPrintTestClasspath"})
+	cmd, err := buildGradleCommand(b.ProjectDir, []string{"cifuzzPrintTestClasspath", "-q"})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION



<!--- provide a general summary of your changes in the title above -->

### Motivation & Context
<!--- why is this change required? what problem does it solve? -->
<!--- if it fixes an open issue, please link to the issue here -->
See: https://github.com/CodeIntelligenceTesting/cifuzz-gradle-plugin/pull/7

### Description
<!--- describe your changes in detail -->
This removes a legacy from before the Gradle plugin. It was called to compile the test code. However, `gradle cifuzzPrintTestClasspath`, which we call next, will take care of compiling the code. This will select the correct compile task(s) depending on which test source set was selected etc.

`testClasses` might also not exist in all projects. Especially Android projects usually do not have it.
 
<!--- Mental Checklist
Go over these following points and check that your PR is complete.
- My code follows the code style and contributing guidelines of this project.
- The title is as descriptive as possible and prefixed with the type of change (e.g. feature, refactor, fix). 
  (Keep in mind that the title will be displayed in the change log)
- My commits are clean and concise and include what changed and why.
- My changes require a change to the documentation and I have updated it accordingly.
- I have added tests to cover my changes and all new and existing tests pass. -->
