### PR TITLE
fix: missing = in coverage --help

### DIFF
--- a/internal/cmd/coverage/coverage.go
+++ b/internal/cmd/coverage/coverage.go
@@ -126,7 +126,7 @@ or a lcov trace file.
     cifuzz coverage <fuzz test>
 
 ` + pterm.Style{pterm.Reset, pterm.Bold}.Sprint("HTML") + `
-    cifuzz coverage --output coverage-report <fuzz test>
+    cifuzz coverage --output=coverage-report <fuzz test>
 
 ` + pterm.Style{pterm.Reset, pterm.Bold}.Sprint("LCOV") + `
     cifuzz coverage --format=lcov <fuzz test>


### PR DESCRIPTION
Using `cifuzz coverage --help` shows how to generate HTML only:

```
HTML
    cifuzz coverage --output coverage-report <fuzz test>
```

But the text was missing an equal: correct is `--output=coverage-report`
