### PR TITLE
fix(installer): Fix zsh completion script symlink loop

### DIFF
--- a/cmd/installer/installer.go
+++ b/cmd/installer/installer.go
@@ -397,6 +397,14 @@ func installZshCompletionScript(installDir string) error {
 	// Try to create a symlink in the first fpath directory
 	completionScript := completionScriptPath(installDir, "zsh")
 	symlinkPath := filepath.Join(fpath, "_cifuzz")
+	// Don't create a symlink if the source and target are the same (that
+	// can be the case if symlink creation failed in a previous install
+	// attempt and the user followed the instructions to add the completion
+	// script to their fpath).
+	if completionScript == symlinkPath {
+		return nil
+	}
+
 	err = fileutil.ForceSymlink(completionScript, symlinkPath)
 	if err != nil {
 		// Creating a symlink in the first fpath directory failed, so we


### PR DESCRIPTION
Consider the following scenario:

1. The installer fails to create a symlink to the first fpath directory
2. User follows the instructions to add the completion script to their fpath
3. The user runs a cifuzz installer again
4. The installer creates a symlink from the first fpath to the completion script.

The symlink created in step 4 creates a symlink loop, because the first fpath is the path to the completion script, so we create a symlink to itself. In effect, zsh hangs whenever the user opens a new shell.

This commit avoids creating such a symlink loop.
