### PR TITLE
examples: Add new example project for clojure with deps.edn build setup

### DIFF
--- a/examples/clojure-deps.edn/README.md
+++ b/examples/clojure-deps.edn/README.md
@@ -12,14 +12,14 @@ clojure "-T:build" "fuzzing-jar"
 
 Then run the fuzzer as follows:
 
-``` shell
+```shell
 java -cp target/fuzzing.jar  com.code_intelligence.jazzer.Jazzer              \
      --target_class=jazzer_clojure_example.targets.SimpleExample
 ```
 
-or 
+or
 
-``` shell
+```shell
 java -cp target/fuzzing.jar  com.code_intelligence.jazzer.Jazzer              \
        --target-class=jazzer_clojure_example.targets.JsonistaExample          \
        /fuzzing/corpus-jsonista

--- a/examples/clojure-deps.edn/README.md
+++ b/examples/clojure-deps.edn/README.md
@@ -1,0 +1,26 @@
+# Demo project for fuzzing clojure code
+
+Example clojure project with two Jazzer fuzz targets.
+
+## Usage
+
+Build a fuzzing JAR with
+
+```shell
+clojure "-T:build" "fuzzing-jar"
+```
+
+Then run the fuzzer as follows:
+
+``` shell
+java -cp target/fuzzing.jar  com.code_intelligence.jazzer.Jazzer              \
+     --target_class=jazzer_clojure_example.targets.SimpleExample
+```
+
+or 
+
+``` shell
+java -cp target/fuzzing.jar  com.code_intelligence.jazzer.Jazzer              \
+       --target-class=jazzer_clojure_example.targets.JsonistaExample          \
+       /fuzzing/corpus-jsonista
+```

--- a/examples/clojure-deps.edn/build.clj
+++ b/examples/clojure-deps.edn/build.clj
@@ -1,0 +1,15 @@
+(ns build
+  (:require
+   [clojure.tools.build.api :as build]))
+
+(defn fuzzing-jar [_]
+  (build/delete {:path "target"})
+  (let [basis (build/create-basis {:project "deps.edn"
+                                   :aliases [:jazzer]})]
+    (build/compile-clj {:basis basis
+                        :src-dirs ["src"]
+                        :class-dir "target/classes"})
+    (build/uber {:basis basis
+                 :class-dir "target/classes"
+                 :uber-file "target/fuzzing.jar"})
+  (println "Fuzzing jar created: target/fuzzing.jar")))

--- a/examples/clojure-deps.edn/deps.edn
+++ b/examples/clojure-deps.edn/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        metosin/jsonista {:mvn/version "0.3.5"}
+        com.code-intelligence/jazzer-clj {:mvn/version "0.1.0"}}
+ :aliases {:jazzer {:extra-deps {com.code-intelligence/jazzer {:mvn/version "0.20.1"}
+                                 com.code-intelligence/jazzer-api {:mvn/version "0.20.1"}}}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}}
+                   :ns-default build}}}

--- a/examples/clojure-deps.edn/src/jazzer_clojure_example/core.clj
+++ b/examples/clojure-deps.edn/src/jazzer_clojure_example/core.clj
@@ -1,0 +1,28 @@
+(ns jazzer-clojure-example.core
+  (:require [com.code-intelligence.jazzer-clj.core :as fuzzing]
+            ;; This is just an example of code that we might want to test.
+            [jsonista.core :as json]))
+
+;;; First, the example from the jazzer-clj README.
+
+(defn do-something
+  "Not a very useful piece of code."
+  [s]
+  (when (= "supersecret" s)
+    (throw (Exception. "You found the bug!"))))
+
+(fuzzing/deftarget jazzer_clojure_example.targets.SimpleExample [input]
+  ;; We ask the fuzzer for a string because that's the input needed for
+  ;; `do-something`.
+  (do-something (.consumeRemainingAsString input)))
+
+;;; Alternatively, let's test some library code!
+
+(fuzzing/deftarget jazzer_clojure_example.targets.JsonistaExample [input]
+  ;; json/read-value expects a string, so we ask the fuzzer to give us string
+  ;; data, and then we just feed that data into the library function.
+  (try (json/read-value (.consumeRemainingAsString input))
+       ;; IOException is the expected reaction when the input is malformed. It's
+       ;; part of the library's interface, so we catch and ignore the exception
+       ;; to prevent the fuzzer from reporting it as a bug.
+       (catch java.io.IOException _ nil)))


### PR DESCRIPTION
<!--- provide a general summary of your changes in the title above -->

<!--- Mental Checklist
Go over these following points and check that your PR is complete.
- My code follows the code style and contributing guidelines of this project.
- The title is as descriptive as possible and prefixed with the type of change (e.g. feat, refactor, fix).
  (Keep in mind that the title will be displayed in the change log)
- My commits are clean and concise and include what changed and why.
- My changes require a change to the documentation and I have updated it accordingly.
- I have added tests to cover my changes and all new and existing tests pass.
- I provided steps for reviewers and users to test out my changes.
- My description is written in a way that externals can understand my changes. -->

### Motivation/Context

<!--- why is this change required? what problem does it solve? -->

This new example project should be helpful for adding clojure support to `cifuzz` with a modern clojure setup.

### Description

<!--- describe your changes in detail -->
<!--- if you have multiple commits, how do they connect? -->

This adds a small example project for clojure with a typical `deps.edn` / `build.clj` setup (in contrast to the formerly more common `leiningen` setup.)

This project uses the clojure bindings for jazzer which can be found under [jazzer-clj](https://github.com/CodeIntelligenceTesting/jazzer-clj).

### How to use/reproduce

<!--- describe how reviewers can test your changes -->

When clojure is installed, this project can be built using

```bash
clojure "-T:build" "fuzzing-jar"
```
and run using

```bash
java -cp target/fuzzing.jar  com.code_intelligence.jazzer.Jazzer              \
     --target_class=jazzer_clojure_example.targets.SimpleExample
```

More examples can be found in the projects readme and under [jazzer-clojure-example](https://github.com/CodeIntelligenceTesting/jazzer-clojure-example).
