### PR TITLE
chore(deps): update jazzer to v0.20.1

### DIFF
--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -16,12 +16,23 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Use JUnit Jupiter for testing. -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Use Jazzer for fuzzing -->

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
-            <version>0.19.0</version>
+            <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/errors/java/testdata-sql-ldap/pom.xml
+++ b/integration-tests/errors/java/testdata-sql-ldap/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
-            <version>0.19.0</version>
+            <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/errors/java/testdata-sql-ldap/pom.xml
+++ b/integration-tests/errors/java/testdata-sql-ldap/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -23,32 +23,46 @@
             </plugin>
         </plugins>
     </build>
-    
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
             <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>2.2.220</version>
         </dependency>
+
         <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
             <version>6.0.8</version>
         </dependency>
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>cifuzz</id>

--- a/integration-tests/errors/java/testdata/pom.xml
+++ b/integration-tests/errors/java/testdata/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -23,22 +23,34 @@
             </plugin>
         </plugins>
     </build>
-    
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
             <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>cifuzz</id>

--- a/integration-tests/errors/java/testdata/pom.xml
+++ b/integration-tests/errors/java/testdata/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
-            <version>0.19.0</version>
+            <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/java-maven-spring/testdata/pom.xml
+++ b/integration-tests/java-maven-spring/testdata/pom.xml
@@ -15,7 +15,33 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>junit-spring-web</name>
 	<description>Demo project for Spring Boot</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 	<dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.code-intelligence</groupId>
+            <artifactId>jazzer-junit</artifactId>
+            <version>0.20.1</version>
+            <scope>test</scope>
+        </dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -33,29 +59,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.code-intelligence</groupId>
-			<artifactId>jazzer-junit</artifactId>
-			<version>0.20.1</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>2.1.212</version>
 			<scope>compile</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>5.9.2</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.9.2</version>
 		</dependency>
 	</dependencies>
 

--- a/integration-tests/java-maven-spring/testdata/pom.xml
+++ b/integration-tests/java-maven-spring/testdata/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>com.code-intelligence</groupId>
 			<artifactId>jazzer-junit</artifactId>
-			<version>0.19.0</version>
+			<version>0.20.1</version>
 		</dependency>
 
 		<dependency>

--- a/integration-tests/java-maven/java_maven_test.go
+++ b/integration-tests/java-maven/java_maven_test.go
@@ -57,8 +57,8 @@ func TestIntegration_Maven(t *testing.T) {
 	shared.AddLinesToFileAtBreakPoint(t,
 		filepath.Join(projectDir, "pom.xml"),
 		strings.Split(strings.Split(strings.Join(linesToAdd, "\n"), "<plugin>")[0], "\n"),
-		"    </dependencies>",
-		false,
+		"    </properties>",
+		true,
 	)
 	shared.AddLinesToFileAtBreakPoint(t,
 		filepath.Join(projectDir, "pom.xml"),
@@ -338,7 +338,7 @@ func testBundle(t *testing.T, dir string, cifuzz string, args ...string) {
 	jarPattern := filepath.Join(archiveDir, "runtime_deps", "*.jar")
 	jarMatches, err := zglob.Glob(jarPattern)
 	require.NoError(t, err)
-	assert.Equal(t, 11, len(jarMatches))
+	assert.Equal(t, 12, len(jarMatches))
 
 	classPattern := filepath.Join(archiveDir, "runtime_deps", "**", "*.class")
 	classMatches, err := zglob.Glob(classPattern)

--- a/integration-tests/java-maven/testdata/pom.xml
+++ b/integration-tests/java-maven/testdata/pom.xml
@@ -15,11 +15,6 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
-    <dependencies>
-        <!-- Use JUnit Jupiter for testing. -->
-
-    </dependencies>
-
     <profiles>
     </profiles>
 

--- a/internal/bundler/testdata/jazzer/maven/pom.xml
+++ b/internal/bundler/testdata/jazzer/maven/pom.xml
@@ -16,15 +16,25 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <!-- Use JUnit Jupiter for testing. -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Use Jazzer for fuzzing -->
+
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>

--- a/internal/bundler/testdata/jazzer/maven/pom.xml
+++ b/internal/bundler/testdata/jazzer/maven/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
-            <version>0.19.0</version>
+            <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pkg/messaging/instructions/maven
+++ b/pkg/messaging/instructions/maven
@@ -4,7 +4,7 @@ pom.xml to enable fuzz testing:
     <dependency>
       <groupId>com.code-intelligence</groupId>
       <artifactId>jazzer-junit</artifactId>
-      <version>0.19.0</version>
+      <version>0.20.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/pkg/messaging/instructions/maven
+++ b/pkg/messaging/instructions/maven
@@ -1,26 +1,35 @@
-Please make sure to add the following dependency to your
+Please make sure to add the following dependencies to your
 pom.xml to enable fuzz testing:
 
-    <dependency>
-      <groupId>com.code-intelligence</groupId>
-      <artifactId>jazzer-junit</artifactId>
-      <version>0.20.1</version>
-      <scope>test</scope>
-    </dependency>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-We highly recommend using cifuzz with JUnit >=5 to ensure
-easy IDE integration. You can add it with the following
-dependency to your pom.xml:
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.2</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>com.code-intelligence</groupId>
+            <artifactId>jazzer-junit</artifactId>
+            <version>0.20.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 For Jacoco coverage reports, please make sure to include the
-Jacoco plugin in the build section of your pom.xml. 
+Jacoco plugin in the build section of your pom.xml.
 
     <plugin>
         <groupId>org.jacoco</groupId>
@@ -34,18 +43,18 @@ https://www.jacoco.org/jacoco/trunk/doc/maven.html
 Also, please add the following profile in your profiles:
 
     <profile>
-      <id>cifuzz</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <configuration>
-              <formats>${cifuzz.report.format}</formats>
-              <outputDirectory>${cifuzz.report.output}</outputDirectory>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
+        <id>cifuzz</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <configuration>
+                        <formats>${cifuzz.report.format}</formats>
+                        <outputDirectory>${cifuzz.report.output}</outputDirectory>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
     </profile>
 

--- a/test/projects/maven/tests/pom.xml
+++ b/test/projects/maven/tests/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
-            <version>0.19.0</version>
+            <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/test/projects/maven/tests/pom.xml
+++ b/test/projects/maven/tests/pom.xml
@@ -22,19 +22,32 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
             <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.cifuzz.tests</groupId>
             <artifactId>util</artifactId>

--- a/test/projects/maven/util/pom.xml
+++ b/test/projects/maven/util/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
-            <version>0.19.0</version>
+            <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/test/projects/maven/util/pom.xml
+++ b/test/projects/maven/util/pom.xml
@@ -34,24 +34,37 @@
             </plugin>
         </plugins>
     </build>
-    
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.6</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>com.code-intelligence</groupId>
             <artifactId>jazzer-junit</artifactId>
             <version>0.20.1</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
-            <scope>test</scope>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.6</version>
         </dependency>
     </dependencies>
 

--- a/tools/list-fuzz-tests/pom.xml
+++ b/tools/list-fuzz-tests/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>com.code-intelligence</groupId>
 			<artifactId>jazzer-junit</artifactId>
-			<version>0.19.0</version>
+			<version>0.20.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Update all jazzer dependencies to v0.20.1. In addtion the junit-bom dependency has to be added for maven in order to fix an issue with transitive junit dependencies. Without that addition the list-fuzz-test tool does not work anymore.

