### PR TITLE
feat: switch to maven extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Bazel C/C++ projects are currently not supported on Windows.
 
 - Java JDK >= 8 (1.8) (e.g. [OpenJDK](https://openjdk.java.net/install/) or
   [Zulu](https://www.azul.com/downloads/zulu-community/))
-- [Maven](https://maven.apache.org/install.html)
+- [Maven](https://maven.apache.org/install.html) >= 3.3.1
 
 **Ubuntu / Debian**
 

--- a/e2e/tests/init/init_test.go
+++ b/e2e/tests/init/init_test.go
@@ -26,7 +26,7 @@ var initTests = &[]e2e.TestCase{
 		Assert: func(t *testing.T, output e2e.CommandOutput) {
 			assert.EqualValues(t, 0, output.ExitCode)
 			assert.Contains(t, output.Stdall, "Configuration saved in cifuzz.yaml")
-			assert.Contains(t, output.Stdall, "<artifactId>jazzer-junit</artifactId>")
+			assert.Contains(t, output.Stdall, "<artifactId>cifuzz-maven-extension</artifactId>")
 			assert.NotContains(t, output.Stdall, "Failed to create config")
 			output.FileExists("cifuzz.yaml")
 		},

--- a/examples/maven-multi/.gitignore
+++ b/examples/maven-multi/.gitignore
@@ -1,0 +1,7 @@
+target/
+.cifuzz-*/
+*_inputs
+crash-*
+
+# ignore findings for example projects
+src/test/resources/

--- a/examples/maven-multi/.mvn/extensions.xml
+++ b/examples/maven-multi/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/examples/maven-multi/.mvn/extensions.xml
+++ b/examples/maven-multi/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/examples/maven-multi/README.md
+++ b/examples/maven-multi/README.md
@@ -1,0 +1,26 @@
+# cifuzz Maven example
+
+This is a simple Maven based multi-project, already configured with
+**cifuzz**. It should quickly produce a finding, but slow enough to
+see the progress of the fuzzer.
+
+To start make sure you installed **cifuzz** according to the
+main [README](../../README.md).
+
+You can start fuzzing with
+
+```bash
+cifuzz run com.example.FuzzTestCase
+```
+
+## Coverage
+
+cifuzz can generate Java coverage reports using
+[jacoco](https://www.jacoco.org). This example is configured to use both HTML
+and XML (e.g. for IDE support) as output formats.
+
+Run the coverage command after your cifuzz run:
+
+```bash
+cifuzz coverage com.example.FuzzTestCase
+```

--- a/examples/maven-multi/app/pom.xml
+++ b/examples/maven-multi/app/pom.xml
@@ -5,15 +5,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 >
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.github.CodeIntelligenceTesting.cifuzz</groupId>
-	<artifactId>maven-example</artifactId>
+
+	<artifactId>app</artifactId>
 	<version>1.0-SNAPSHOT</version>
 
-	<properties>
-		<cifuzz.fuzztests>true</cifuzz.fuzztests>
-	</properties>
-
-	<build>
-		<!-- Add test source directory here -->
-	</build>
+	<parent>
+		<groupId>com.github.CodeIntelligenceTesting.cifuzz</groupId>
+		<artifactId>maven-multi-example</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
 </project>

--- a/examples/maven-multi/app/src/main/java/com/example/ExploreMe.java
+++ b/examples/maven-multi/app/src/main/java/com/example/ExploreMe.java
@@ -1,0 +1,27 @@
+package com.example;
+
+public class ExploreMe {
+    private int a;
+
+    public ExploreMe(int a) {
+        this.a = a;
+    }
+
+    // Function with multiple paths that can be discovered by a fuzzer.
+    public void exploreMe(int b, String c) {
+        if (a >= 20000) {
+            if (b >= 2000000) {
+                if (b - a < 100000) {
+                    // Trigger Remote Code Execution Bug
+                    if (c.startsWith("@")) {
+                        String className = c.substring(1);
+                        try {
+                            Class.forName(className).newInstance();
+                        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ignored) {
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/maven-multi/cifuzz.yaml
+++ b/examples/maven-multi/cifuzz.yaml
@@ -1,0 +1,45 @@
+## Configuration for a CI Fuzz project
+## Generated on 2023-04-04
+
+## The build system used to build this project. If not set, cifuzz tries
+## to detect the build system automatically.
+## Valid values: "bazel", "cmake", "maven", "gradle", "other".
+#build-system: cmake
+## If the build system type is "other", this command is used by
+## `cifuzz run` to build the fuzz test.
+#build-command: "make my_fuzz_test"
+
+## Directories containing sample inputs for the code under test.
+## See https://llvm.org/docs/LibFuzzer.html#corpus
+#seed-corpus-dirs:
+# - path/to/seed-corpus
+
+## A file containing input language keywords or other interesting byte
+## sequences.
+## See https://llvm.org/docs/LibFuzzer.html#dictionaries
+#dict: path/to/dictionary.dct
+
+## Command-line arguments to pass to libFuzzer.
+## See https://llvm.org/docs/LibFuzzer.html#options
+#engine-args:
+# - -rss_limit_mb=4096
+
+## Maximum time to run fuzz tests. The default is to run indefinitely.
+#timeout: 30m
+
+## By default, fuzz tests are executed in a sandbox to prevent accidental
+## damage to the system. Set to false to run fuzz tests unsandboxed.
+## Only supported on Linux.
+#use-sandbox: false
+
+## Set to true to print output of the `cifuzz run` command as JSON.
+#print-json: true
+
+## Set to true to disable desktop notifications
+#no-notifications: true
+
+## Set URL of CI Sense
+#server: https://app.code-intelligence.com
+
+## Set the project name on CI Sense
+#project: my-project-1a2b3c4d

--- a/examples/maven-multi/pom.xml
+++ b/examples/maven-multi/pom.xml
@@ -5,15 +5,20 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 >
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>com.github.CodeIntelligenceTesting.cifuzz</groupId>
-	<artifactId>maven-example</artifactId>
+	<artifactId>maven-multi-example</artifactId>
 	<version>1.0-SNAPSHOT</version>
 
+	<packaging>pom</packaging>
+
 	<properties>
-		<cifuzz.fuzztests>true</cifuzz.fuzztests>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
-	<build>
-		<!-- Add test source directory here -->
-	</build>
+	<modules>
+		<module>app</module>
+		<module>testsuite</module>
+	</modules>
 </project>

--- a/examples/maven-multi/testsuite/pom.xml
+++ b/examples/maven-multi/testsuite/pom.xml
@@ -5,15 +5,25 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 >
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.github.CodeIntelligenceTesting.cifuzz</groupId>
-	<artifactId>maven-example</artifactId>
+
+	<artifactId>testsuite</artifactId>
 	<version>1.0-SNAPSHOT</version>
+
+	<parent>
+		<groupId>com.github.CodeIntelligenceTesting.cifuzz</groupId>
+		<artifactId>maven-multi-example</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
 
 	<properties>
 		<cifuzz.fuzztests>true</cifuzz.fuzztests>
 	</properties>
 
-	<build>
-		<!-- Add test source directory here -->
-	</build>
+	<dependencies>
+		<dependency>
+			<groupId>com.github.CodeIntelligenceTesting.cifuzz</groupId>
+			<artifactId>app</artifactId>
+			<version>1.0-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/examples/maven-multi/testsuite/src/test/java/com/example/TestCases.java
+++ b/examples/maven-multi/testsuite/src/test/java/com/example/TestCases.java
@@ -1,0 +1,27 @@
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import com.example.ExploreMe;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestCases {
+
+    @FuzzTest
+    void myFuzzTest(FuzzedDataProvider data) {
+        int a = data.consumeInt();
+        int b = data.consumeInt();
+        String c = data.consumeRemainingAsString();
+
+        ExploreMe ex = new ExploreMe(a);
+        ex.exploreMe(b, c);
+    }
+
+    @Test
+    public void unitTest() {
+        ExploreMe ex = new ExploreMe(100);
+        ex.exploreMe(100, "Test");
+    }
+}

--- a/examples/maven/.mvn/extensions.xml
+++ b/examples/maven/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/examples/maven/.mvn/extensions.xml
+++ b/examples/maven/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -17,42 +17,4 @@
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
 	</properties>
-
-	<dependencies>
-		<!-- Use JUnit Jupiter for testing. -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
-			<scope>test</scope>
-		</dependency>
-		<!-- Use Jazzer for fuzzing -->
-		<dependency>
-			<groupId>com.code-intelligence</groupId>
-			<artifactId>jazzer-junit</artifactId>
-			<version>0.21.1</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.1.0</version>
-			</plugin>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
-			</plugin>
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.1</version>
-			</plugin>
-			<plugin>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/integration-tests/errors/java/testdata-sql-ldap/.mvn/extensions.xml
+++ b/integration-tests/errors/java/testdata-sql-ldap/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/integration-tests/errors/java/testdata-sql-ldap/.mvn/extensions.xml
+++ b/integration-tests/errors/java/testdata-sql-ldap/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/integration-tests/errors/java/testdata-sql-ldap/pom.xml
+++ b/integration-tests/errors/java/testdata-sql-ldap/pom.xml
@@ -18,18 +18,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.code-intelligence</groupId>
-			<artifactId>jazzer-junit</artifactId>
-			<version>0.21.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>2.2.220</version>

--- a/integration-tests/errors/java/testdata/.mvn/extensions.xml
+++ b/integration-tests/errors/java/testdata/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/integration-tests/errors/java/testdata/.mvn/extensions.xml
+++ b/integration-tests/errors/java/testdata/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/integration-tests/errors/java/testdata/pom.xml
+++ b/integration-tests/errors/java/testdata/pom.xml
@@ -15,19 +15,4 @@
 		<maven.compiler.target>8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-
-	<dependencies>
-		<dependency>
-			<groupId>com.code-intelligence</groupId>
-			<artifactId>jazzer-junit</artifactId>
-			<version>0.21.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
 </project>

--- a/integration-tests/java-maven-spring/testdata/.mvn/extensions.xml
+++ b/integration-tests/java-maven-spring/testdata/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/integration-tests/java-maven-spring/testdata/.mvn/extensions.xml
+++ b/integration-tests/java-maven-spring/testdata/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/integration-tests/java-maven-spring/testdata/pom.xml
+++ b/integration-tests/java-maven-spring/testdata/pom.xml
@@ -36,29 +36,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.code-intelligence</groupId>
-			<artifactId>jazzer-junit</artifactId>
-			<version>0.21.1</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>2.1.212</version>
 			<scope>compile</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>5.9.2</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.9.2</version>
 		</dependency>
 	</dependencies>
 

--- a/integration-tests/java-maven/java_maven_test.go
+++ b/integration-tests/java-maven/java_maven_test.go
@@ -350,7 +350,7 @@ func testBundle(t *testing.T, dir string, cifuzz string, args ...string) {
 	jarPattern := filepath.Join(archiveDir, "runtime_deps", "*.jar")
 	jarMatches, err := zglob.Glob(jarPattern)
 	require.NoError(t, err)
-	assert.Equal(t, 13, len(jarMatches))
+	assert.Len(t, jarMatches, 13, "Unexpected number of jars")
 
 	classPattern := filepath.Join(archiveDir, "runtime_deps", "**", "*.class")
 	classMatches, err := zglob.Glob(classPattern)

--- a/integration-tests/shared/cifuzz_runner.go
+++ b/integration-tests/shared/cifuzz_runner.go
@@ -108,6 +108,7 @@ func (r *CIFuzzRunner) Command(t *testing.T, command string, opts *CommandOption
 	return stdErrOutput
 }
 
+// FilterForInstructions returns all indented lines.
 func FilterForInstructions(lines []string) []string {
 	var linesToAdd []string
 	for _, line := range lines {
@@ -118,12 +119,40 @@ func FilterForInstructions(lines []string) []string {
 	return linesToAdd
 }
 
+// FilterForInstructionBlocks returns blocks of indented lines.
+func FilterForInstructionBlocks(lines []string) [][]string {
+	var blocks [][]string
+	inBlock := false
+	currBlock := []string{}
+	for _, line := range lines {
+		if strings.HasPrefix(line, "    ") {
+			inBlock = true
+			currBlock = append(currBlock, line)
+		} else {
+			if inBlock {
+				blocks = append(blocks, currBlock)
+				currBlock = []string{}
+			}
+			inBlock = false
+		}
+	}
+	return blocks
+}
+
 // CommandWithFilterForInstructions runs "cifuzz <command> <args>" and
 // returns any indented lines which the command prints to stderr
 // (which we expect to be lines which should be added to some source or config file).
 func (r *CIFuzzRunner) CommandWithFilterForInstructions(t *testing.T, command string, opts *CommandOptions) []string {
 	allLines := r.Command(t, command, opts)
 	return FilterForInstructions(allLines)
+}
+
+// CommandWithFilterForInstructionBlocks runs "cifuzz <command> <args>" and
+// returns blocks of indented lines which the command prints to stderr
+// (which we expect to be lines which should be added to some source or config file).
+func (r *CIFuzzRunner) CommandWithFilterForInstructionBlocks(t *testing.T, command string, opts *CommandOptions) [][]string {
+	allLines := r.Command(t, command, opts)
+	return FilterForInstructionBlocks(allLines)
 }
 
 type RunOptions struct {

--- a/internal/build/java/maven/testdata/.mvn/extensions.xml
+++ b/internal/build/java/maven/testdata/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/internal/build/java/maven/testdata/.mvn/extensions.xml
+++ b/internal/build/java/maven/testdata/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/internal/bundler/testdata/jazzer/maven/.mvn/extensions.xml
+++ b/internal/bundler/testdata/jazzer/maven/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/internal/bundler/testdata/jazzer/maven/.mvn/extensions.xml
+++ b/internal/bundler/testdata/jazzer/maven/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/internal/bundler/testdata/jazzer/maven/pom.xml
+++ b/internal/bundler/testdata/jazzer/maven/pom.xml
@@ -17,42 +17,4 @@
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
 	</properties>
-
-	<dependencies>
-		<!-- Use JUnit Jupiter for testing. -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
-			<scope>test</scope>
-		</dependency>
-		<!-- Use Jazzer for fuzzing -->
-		<dependency>
-			<groupId>com.code-intelligence</groupId>
-			<artifactId>jazzer-junit</artifactId>
-			<version>0.21.1</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.1.0</version>
-			</plugin>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
-			</plugin>
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.1</version>
-			</plugin>
-			<plugin>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/internal/cmd/coverage/coverage.go
+++ b/internal/cmd/coverage/coverage.go
@@ -317,7 +317,10 @@ func (c *coverageCmd) run() error {
 		if c.opts.BuildSystem == config.BuildSystemGradle {
 			deps, err = gradle.GetDependencies(c.opts.ProjectDir)
 		} else {
-			deps, err = maven.GetDependencies(c.opts.ProjectDir, c.opts.buildStderr)
+			deps, err = maven.GetDependencies(c.opts.ProjectDir, maven.ParallelOptions{
+				Enabled: viper.IsSet("build-jobs"),
+				NumJobs: c.opts.NumBuildJobs,
+			})
 		}
 		if err != nil {
 			return err

--- a/internal/cmdutils/resolve/testdata/maven/.mvn/extensions.xml
+++ b/internal/cmdutils/resolve/testdata/maven/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/internal/cmdutils/resolve/testdata/maven/.mvn/extensions.xml
+++ b/internal/cmdutils/resolve/testdata/maven/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/internal/cmdutils/resolve/testdata/maven/pom.xml
+++ b/internal/cmdutils/resolve/testdata/maven/pom.xml
@@ -9,6 +9,10 @@
 	<artifactId>maven-example</artifactId>
 	<version>1.0-SNAPSHOT</version>
 
+	<properties>
+		<cifuzz.fuzztests>true</cifuzz.fuzztests>
+	</properties>
+
 	<build>
 		<testSourceDirectory>src/test</testSourceDirectory>
 	</build>

--- a/pkg/messaging/instructions/maven
+++ b/pkg/messaging/instructions/maven
@@ -1,20 +1,17 @@
-Please make sure to add the following dependency to your
-pom.xml to enable fuzz testing:
+Apply the CI Fuzz Maven extension to your Maven project by adding the following configuration block to your `.mvn/extensions.xml` file:
 
-    <dependency>
-      <groupId>com.code-intelligence</groupId>
-      <artifactId>jazzer-junit</artifactId>
-      <version>0.21.1</version>
-      <scope>test</scope>
-    </dependency>
+    <extensions>
+      <extension>
+        <groupId>com.code-intelligence</groupId>
+        <artifactId>cifuzz-maven-extension</artifactId>
+        <version>1.0.0-rc2</version>
+      </extension>
+    </extensions>
 
-We highly recommend using cifuzz with JUnit >=5 to ensure
-easy IDE integration. You can add it with the following
-dependency to your pom.xml:
+In a **multi-project**, you have to mark the project that contains the fuzz tests by setting the `cifuzz.fuzztests` property in the `<project-folder>/pom.xml`:
 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.2</version>
-      <scope>test</scope>
-    </dependency>
+    <properties>
+      <cifuzz.fuzztests>true</cifuzz.fuzztests>
+    </properties>
+
+By default, the `cifuzz.yaml` should be located in the root of your Maven project.

--- a/test/projects/maven/.mvn/extensions.xml
+++ b/test/projects/maven/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>com.code-intelligence</groupId>
 		<artifactId>cifuzz-maven-extension</artifactId>
-		<version>1.0.0-rc2</version>
+		<version>1.0.0</version>
 	</extension>
 </extensions>

--- a/test/projects/maven/.mvn/extensions.xml
+++ b/test/projects/maven/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+	<extension>
+		<groupId>com.code-intelligence</groupId>
+		<artifactId>cifuzz-maven-extension</artifactId>
+		<version>1.0.0-rc2</version>
+	</extension>
+</extensions>

--- a/test/projects/maven/tests/pom.xml
+++ b/test/projects/maven/tests/pom.xml
@@ -13,23 +13,15 @@
 	<artifactId>tests</artifactId>
 	<name>tests</name>
 
+	<properties>
+		<cifuzz.fuzztests>true</cifuzz.fuzztests>
+	</properties>
+
 	<build>
 		<testSourceDirectory>fuzzTests</testSourceDirectory>
 	</build>
 
 	<dependencies>
-		<dependency>
-			<groupId>com.code-intelligence</groupId>
-			<artifactId>jazzer-junit</artifactId>
-			<version>0.21.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>com.cifuzz.tests</groupId>
 			<artifactId>util</artifactId>

--- a/test/projects/maven/util/pom.xml
+++ b/test/projects/maven/util/pom.xml
@@ -13,23 +13,15 @@
 	<artifactId>util</artifactId>
 	<name>util</name>
 
+	<properties>
+		<cifuzz.fuzztests>true</cifuzz.fuzztests>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.6</version>
-		</dependency>
-		<dependency>
-			<groupId>com.code-intelligence</groupId>
-			<artifactId>jazzer-junit</artifactId>
-			<version>0.21.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/tools/updater/updater.go
+++ b/tools/updater/updater.go
@@ -46,22 +46,26 @@ func main() {
 		for _, path := range paths {
 			updateFile(path, *version, re)
 		}
-	case "jazzer":
-		re := regexp.MustCompile(`(<artifactId>jazzer-junit<\/artifactId>\s*<version>)(?P<version>\d+.\d+.\d+.*)(<\/version>)`)
+	case "maven-extension":
+		re := regexp.MustCompile(`(<artifactId>cifuzz-maven-extension<\/artifactId>\s*<version>)(?P<version>\d+.\d+.\d+.*)(<\/version>)`)
 		paths := []string{
-			"examples/maven/pom.xml",
-			"integration-tests/errors/java/testdata/pom.xml",
-			"integration-tests/errors/java/testdata-sql-ldap/pom.xml",
-			"integration-tests/java-maven-spring/testdata/pom.xml",
-			"internal/bundler/testdata/jazzer/maven/pom.xml",
+			"integration-tests/java-maven-spring/testdata/.mvn/extensions.xml",
+			"integration-tests/errors/java/testdata/.mvn/extensions.xml",
+			"integration-tests/errors/java/testdata-sql-ldap/.mvn/extensions.xml",
+			"examples/maven-multi/.mvn/extensions.xml",
+			"examples/maven/.mvn/extensions.xml",
+			"test/projects/maven/.mvn/extensions.xml",
+			"internal/bundler/testdata/jazzer/maven/.mvn/extensions.xml",
+			"internal/cmdutils/resolve/testdata/maven/.mvn/extensions.xml",
+			"internal/build/java/maven/testdata/.mvn/extensions.xml",
 			"pkg/messaging/instructions/maven",
-			"test/projects/maven/tests/pom.xml",
-			"test/projects/maven/util/pom.xml",
-			"tools/list-fuzz-tests/pom.xml",
 		}
 		for _, path := range paths {
 			updateFile(path, *version, re)
 		}
+	case "jazzer":
+		re := regexp.MustCompile(`(<artifactId>jazzer-junit<\/artifactId>\s*<version>)(?P<version>\d+.\d+.\d+.*)(<\/version>)`)
+		updateFile("tools/list-fuzz-tests/pom.xml", *version, re)
 	case "jazzerjs":
 		updateJazzerNpm("examples/nodejs", *version)
 		updateJazzerNpm("examples/nodejs-typescript", *version)


### PR DESCRIPTION
### Motivation/Context
https://github.com/CodeIntelligenceTesting/cifuzz-maven-extension

### Description

- Use similar means to get information directly from the build tool (Requires 'cifuzz-maven-extension')
- Improve getting the jacoco.xml path from build tool
- Fix issues with multi-projects

With this there is certain duplication of code in 'maven.go' and 'gradle.go'. Ideally, both can be combined into one integration for "Java projects". Where only the command lines to call the tools differ but the processing of information is the same for both.

